### PR TITLE
Add shapes for the corner radiuses

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/Shapes.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/Shapes.kt
@@ -23,5 +23,8 @@ import androidx.compose.material3.Shapes
 import androidx.compose.ui.unit.dp
 
 val Shapes = Shapes(
+    extraSmall = RoundedCornerShape(4.dp),
+    small = RoundedCornerShape(8.dp),
     medium = RoundedCornerShape(16.dp),
+    extraLarge = RoundedCornerShape(50),
 )


### PR DESCRIPTION
This PR tries to add basic values for radiuses across the app.

From a quick look at the specs, this seems to be the commonly used values. Mainly 16dp and 50%, but there also are some rare occurrences of 4dp and 8dp.

Depends on #10 