### PR TITLE
Add fab to the sent main screens

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/MainScreenFab.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/MainScreenFab.kt
@@ -18,13 +18,41 @@
 
 package com.infomaniak.swisstransfer.ui.components
 
-import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
+import android.content.Intent
+import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.FloatingActionButtonElevation
 import androidx.compose.runtime.Composable
-import com.infomaniak.swisstransfer.ui.screen.main.LocalNavType
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.infomaniak.swisstransfer.ui.NewTransferActivity
 
 @Composable
-fun MainScreenFab(navType: NavigationSuiteType, navigateToNewTransfer: () -> Unit) {
-    if (navType == NavigationSuiteType.NavigationBar) {
-        SwissTransferFab(onClick = navigateToNewTransfer)
+fun MainScreenFab(
+    modifier: Modifier = Modifier,
+    mainScreenFabType: MainScreenFabType
+) {
+    val context = LocalContext.current
+    SwissTransferFab(
+        modifier = modifier,
+        fabType = mainScreenFabType.fabType,
+        elevation = mainScreenFabType.elevation(),
+        onClick = { context.startActivity(Intent(context, NewTransferActivity::class.java)) },
+    )
+}
+
+enum class MainScreenFabType(val fabType: FabType, private val defaultElevation: Dp?) {
+    BOTTOM_BAR(FabType.NORMAL, null),
+    EMPTY_STATE(FabType.BIG, null),
+    NAVIGATION_RAIL(FabType.NORMAL, 0.dp);
+
+    @Composable
+    fun elevation(): FloatingActionButtonElevation {
+        return if (defaultElevation != null) {
+            FloatingActionButtonDefaults.elevation(defaultElevation = 0.dp)
+        } else {
+            FloatingActionButtonDefaults.elevation()
+        }
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/MainScreenFab.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/MainScreenFab.kt
@@ -16,16 +16,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.infomaniak.swisstransfer.ui.theme
+package com.infomaniak.swisstransfer.ui.components
 
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Shapes
-import androidx.compose.ui.unit.dp
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
+import androidx.compose.runtime.Composable
+import com.infomaniak.swisstransfer.ui.screen.main.LocalNavType
 
-val Shapes = Shapes(
-    extraSmall = RoundedCornerShape(4.dp),
-    small = RoundedCornerShape(8.dp),
-    medium = RoundedCornerShape(16.dp),
-    large = RoundedCornerShape(24.dp),
-    extraLarge = RoundedCornerShape(50),
-)
+@Composable
+fun MainScreenFab(navigateToNewTransfer: () -> Unit) {
+    if (LocalNavType.current == NavigationSuiteType.NavigationBar) {
+        SwissTransferFab(onClick = navigateToNewTransfer)
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/MainScreenFab.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/MainScreenFab.kt
@@ -23,8 +23,8 @@ import androidx.compose.runtime.Composable
 import com.infomaniak.swisstransfer.ui.screen.main.LocalNavType
 
 @Composable
-fun MainScreenFab(navigateToNewTransfer: () -> Unit) {
-    if (LocalNavType.current == NavigationSuiteType.NavigationBar) {
+fun MainScreenFab(navType: NavigationSuiteType, navigateToNewTransfer: () -> Unit) {
+    if (navType == NavigationSuiteType.NavigationBar) {
         SwissTransferFab(onClick = navigateToNewTransfer)
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/NewTransferFab.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/NewTransferFab.kt
@@ -18,7 +18,6 @@
 
 package com.infomaniak.swisstransfer.ui.components
 
-import android.content.Intent
 import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.FloatingActionButtonElevation
 import androidx.compose.runtime.Composable
@@ -27,6 +26,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.infomaniak.swisstransfer.ui.NewTransferActivity
+import com.infomaniak.swisstransfer.ui.utils.launchActivity
 
 @Composable
 fun NewTransferFab(
@@ -38,7 +38,7 @@ fun NewTransferFab(
         modifier = modifier,
         fabType = newTransferFabType.fabType,
         elevation = newTransferFabType.elevation(),
-        onClick = { context.startActivity(Intent(context, NewTransferActivity::class.java)) },
+        onClick = { context.launchActivity(NewTransferActivity::class) },
     )
 }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/NewTransferFab.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/NewTransferFab.kt
@@ -29,20 +29,20 @@ import androidx.compose.ui.unit.dp
 import com.infomaniak.swisstransfer.ui.NewTransferActivity
 
 @Composable
-fun MainScreenFab(
+fun NewTransferFab(
     modifier: Modifier = Modifier,
-    mainScreenFabType: MainScreenFabType
+    newTransferFabType: NewTransferFabType
 ) {
     val context = LocalContext.current
     SwissTransferFab(
         modifier = modifier,
-        fabType = mainScreenFabType.fabType,
-        elevation = mainScreenFabType.elevation(),
+        fabType = newTransferFabType.fabType,
+        elevation = newTransferFabType.elevation(),
         onClick = { context.startActivity(Intent(context, NewTransferActivity::class.java)) },
     )
 }
 
-enum class MainScreenFabType(val fabType: FabType, private val defaultElevation: Dp?) {
+enum class NewTransferFabType(val fabType: FabType, private val defaultElevation: Dp?) {
     BOTTOM_BAR(FabType.NORMAL, null),
     EMPTY_STATE(FabType.BIG, null),
     NAVIGATION_RAIL(FabType.NORMAL, 0.dp);

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/NewTransferFab.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/NewTransferFab.kt
@@ -50,7 +50,7 @@ enum class NewTransferFabType(val fabType: FabType, private val defaultElevation
     @Composable
     fun elevation(): FloatingActionButtonElevation {
         return if (defaultElevation != null) {
-            FloatingActionButtonDefaults.elevation(defaultElevation = 0.dp)
+            FloatingActionButtonDefaults.elevation(defaultElevation)
         } else {
             FloatingActionButtonDefaults.elevation()
         }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferFab.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferFab.kt
@@ -22,30 +22,33 @@ import android.content.res.Configuration
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CornerBasedShape
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.FloatingActionButtonElevation
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.icons.AppIcons
 import com.infomaniak.swisstransfer.ui.icons.app.Add
 import com.infomaniak.swisstransfer.ui.theme.Shapes
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 
 @Composable
-fun SwissTransferFab(modifier: Modifier = Modifier, fabType: FabType = FabType.NORMAL, onClick: () -> Unit) {
+fun SwissTransferFab(
+    modifier: Modifier = Modifier,
+    fabType: FabType = FabType.NORMAL,
+    elevation: FloatingActionButtonElevation = FloatingActionButtonDefaults.elevation(),
+    onClick: () -> Unit,
+) {
     FloatingActionButton(
-        modifier = modifier.let {
-            if (fabType == FabType.BIG) it.size(80.dp) else it
-        },
+        modifier = modifier.let { if (fabType == FabType.BIG) it.size(80.dp) else it },
         onClick = onClick,
         containerColor = SwissTransferTheme.materialColors.primary,
-        contentColor = SwissTransferTheme.materialColors.onPrimary,
         shape = fabType.shape,
+        elevation = elevation,
     ) {
-        Icon(imageVector = AppIcons.Add, contentDescription = stringResource(id = R.string.sentTitle))
+        Icon(imageVector = AppIcons.Add, contentDescription = "TODO")
     }
 }
 
@@ -53,6 +56,7 @@ enum class FabType(val shape: CornerBasedShape) {
     NORMAL(Shapes.medium),
     BIG(Shapes.large),
 }
+
 
 @Preview
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferFab.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferFab.kt
@@ -1,0 +1,73 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.infomaniak.swisstransfer.ui.components
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.infomaniak.swisstransfer.R
+import com.infomaniak.swisstransfer.ui.icons.AppIcons
+import com.infomaniak.swisstransfer.ui.icons.app.Add
+import com.infomaniak.swisstransfer.ui.theme.Shapes
+import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
+
+@Composable
+fun SwissTransferFab(modifier: Modifier = Modifier, fabType: FabType = FabType.NORMAL, onClick: () -> Unit) {
+    FloatingActionButton(
+        modifier = modifier.let {
+            if (fabType == FabType.BIG) it.size(80.dp) else it
+        },
+        onClick = onClick,
+        containerColor = SwissTransferTheme.materialColors.primary,
+        contentColor = SwissTransferTheme.materialColors.onPrimary,
+        shape = fabType.shape,
+    ) {
+        Icon(imageVector = AppIcons.Add, contentDescription = stringResource(id = R.string.sentTitle))
+    }
+}
+
+enum class FabType(val shape: CornerBasedShape) {
+    NORMAL(Shapes.medium),
+    BIG(Shapes.large),
+}
+
+@Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)
+@Composable
+private fun SwissTransferFabPreview() {
+    SwissTransferTheme {
+        SwissTransferFab(onClick = {})
+    }
+}
+
+@Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)
+@Composable
+private fun SwissTransferFabBigPreview() {
+    SwissTransferTheme {
+        SwissTransferFab(fabType = FabType.BIG, onClick = {})
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferFab.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferFab.kt
@@ -27,8 +27,10 @@ import androidx.compose.material3.FloatingActionButtonElevation
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.icons.AppIcons
 import com.infomaniak.swisstransfer.ui.icons.app.Add
 import com.infomaniak.swisstransfer.ui.theme.Shapes
@@ -48,7 +50,10 @@ fun SwissTransferFab(
         shape = fabType.shape,
         elevation = elevation,
     ) {
-        Icon(imageVector = AppIcons.Add, contentDescription = "TODO")
+        Icon(
+            imageVector = AppIcons.Add,
+            contentDescription = stringResource(id = R.string.contentDescriptionCreateNewTransferButton),
+        )
     }
 }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/icons/app/Add.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/icons/app/Add.kt
@@ -1,0 +1,65 @@
+package com.infomaniak.swisstransfer.ui.icons.app
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Round
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.group
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.infomaniak.swisstransfer.ui.icons.AppIcons
+
+val AppIcons.Add: ImageVector
+    get() {
+        if (_add != null) {
+            return _add!!
+        }
+        _add = Builder(
+            name = "Add",
+            defaultWidth = 24.0.dp,
+            defaultHeight = 24.0.dp,
+            viewportWidth = 24.0f,
+            viewportHeight = 24.0f
+        ).apply {
+            group {
+                path(
+                    fill = null,
+                    stroke = SolidColor(Color(0xFF9f9f9f)),
+                    strokeLineWidth = 2.0f,
+                    strokeLineCap = Round,
+                    strokeLineJoin = StrokeJoin.Round,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero
+                ) {
+                    moveTo(1.5f, 12.0f)
+                    horizontalLineToRelative(21.0f)
+                    moveTo(12.0f, 1.5f)
+                    verticalLineToRelative(21.0f)
+                }
+            }
+        }.build()
+        return _add!!
+    }
+
+private var _add: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box {
+        Image(
+            imageVector = AppIcons.Add,
+            contentDescription = null,
+            modifier = Modifier.size(250.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/MainNavHost.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/MainNavHost.kt
@@ -18,17 +18,14 @@
 
 package com.infomaniak.swisstransfer.ui.screen.main
 
-import android.content.Intent
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.adaptive.WindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import com.infomaniak.swisstransfer.ui.NewTransferActivity
 import com.infomaniak.swisstransfer.ui.navigation.MainNavigation
 import com.infomaniak.swisstransfer.ui.navigation.MainNavigation.*
 import com.infomaniak.swisstransfer.ui.screen.main.received.ReceivedScreen
@@ -41,13 +38,10 @@ fun MainNavHost(
     navController: NavHostController,
     windowAdaptiveInfo: WindowAdaptiveInfo,
 ) {
-    val context = LocalContext.current
-
     NavHost(navController, MainNavigation.startDestination, modifier = Modifier.safeDrawingPadding()) {
         composable<SentDestination> {
             SentScreen(
                 navigateToDetails = { navController.navigate(TransferDetailsDestination(it)) },
-                navigateToNewTransfer = { context.startActivity(Intent(context, NewTransferActivity::class.java)) },
             )
         }
         composable<ReceivedDestination> {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/MainNavHost.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/MainNavHost.kt
@@ -18,17 +18,19 @@
 
 package com.infomaniak.swisstransfer.ui.screen.main
 
+import android.content.Intent
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.adaptive.WindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import com.infomaniak.swisstransfer.ui.NewTransferActivity
 import com.infomaniak.swisstransfer.ui.navigation.MainNavigation
 import com.infomaniak.swisstransfer.ui.navigation.MainNavigation.*
-import com.infomaniak.swisstransfer.ui.navigation.NewTransferNavigation
 import com.infomaniak.swisstransfer.ui.screen.main.received.ReceivedScreen
 import com.infomaniak.swisstransfer.ui.screen.main.sent.SentScreen
 import com.infomaniak.swisstransfer.ui.screen.main.settings.SettingsScreenWrapper
@@ -39,11 +41,13 @@ fun MainNavHost(
     navController: NavHostController,
     windowAdaptiveInfo: WindowAdaptiveInfo,
 ) {
+    val context = LocalContext.current
+
     NavHost(navController, MainNavigation.startDestination, modifier = Modifier.safeDrawingPadding()) {
         composable<SentDestination> {
             SentScreen(
                 navigateToDetails = { navController.navigate(TransferDetailsDestination(it)) },
-                navigateToNewTransfer = { navController.navigate(NewTransferNavigation.ImportFilesDestination) },
+                navigateToNewTransfer = { context.startActivity(Intent(context, NewTransferActivity::class.java)) },
             )
         }
         composable<ReceivedDestination> {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/MainNavHost.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/MainNavHost.kt
@@ -28,6 +28,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.infomaniak.swisstransfer.ui.navigation.MainNavigation
 import com.infomaniak.swisstransfer.ui.navigation.MainNavigation.*
+import com.infomaniak.swisstransfer.ui.navigation.NewTransferNavigation
 import com.infomaniak.swisstransfer.ui.screen.main.received.ReceivedScreen
 import com.infomaniak.swisstransfer.ui.screen.main.sent.SentScreen
 import com.infomaniak.swisstransfer.ui.screen.main.settings.SettingsScreenWrapper
@@ -42,6 +43,7 @@ fun MainNavHost(
         composable<SentDestination> {
             SentScreen(
                 navigateToDetails = { navController.navigate(TransferDetailsDestination(it)) },
+                navigateToNewTransfer = { navController.navigate(NewTransferNavigation.ImportFilesDestination) },
             )
         }
         composable<ReceivedDestination> {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/components/AppNavigationSuiteScaffold.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/components/AppNavigationSuiteScaffold.kt
@@ -27,8 +27,8 @@ import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.infomaniak.swisstransfer.ui.components.MainScreenFab
-import com.infomaniak.swisstransfer.ui.components.MainScreenFabType
+import com.infomaniak.swisstransfer.ui.components.NewTransferFab
+import com.infomaniak.swisstransfer.ui.components.NewTransferFabType
 import com.infomaniak.swisstransfer.ui.navigation.MainNavigation
 import com.infomaniak.swisstransfer.ui.navigation.NavigationItem
 import com.infomaniak.swisstransfer.ui.theme.Margin
@@ -116,9 +116,9 @@ private fun AppNavigationRail(
 ) {
     NavigationRail(
         header = {
-            MainScreenFab(
+            NewTransferFab(
                 modifier = Modifier.padding(vertical = Margin.Large),
-                mainScreenFabType = MainScreenFabType.NAVIGATION_RAIL,
+                newTransferFabType = NewTransferFabType.NAVIGATION_RAIL,
             )
         },
         containerColor = SwissTransferTheme.colors.navigationItemBackground

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/components/AppNavigationSuiteScaffold.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/components/AppNavigationSuiteScaffold.kt
@@ -117,7 +117,7 @@ private fun AppNavigationRail(
     NavigationRail(
         header = {
             NewTransferFab(
-                modifier = Modifier.padding(vertical = Margin.Large),
+                modifier = Modifier.padding(vertical = Margin.Medium),
                 newTransferFabType = NewTransferFabType.NAVIGATION_RAIL,
             )
         },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/components/AppNavigationSuiteScaffold.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/components/AppNavigationSuiteScaffold.kt
@@ -19,8 +19,6 @@
 package com.infomaniak.swisstransfer.ui.screen.main.components
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.*
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuite
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
@@ -29,6 +27,8 @@ import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import com.infomaniak.swisstransfer.ui.components.MainScreenFab
+import com.infomaniak.swisstransfer.ui.components.MainScreenFabType
 import com.infomaniak.swisstransfer.ui.navigation.MainNavigation
 import com.infomaniak.swisstransfer.ui.navigation.NavigationItem
 import com.infomaniak.swisstransfer.ui.theme.Margin
@@ -116,9 +116,10 @@ private fun AppNavigationRail(
 ) {
     NavigationRail(
         header = {
-            FloatingActionButton(onClick = {}, modifier = Modifier.padding(bottom = Margin.Large)) {
-                Icon(Icons.Default.Add, contentDescription = null)
-            }
+            MainScreenFab(
+                modifier = Modifier.padding(vertical = Margin.Large),
+                mainScreenFabType = MainScreenFabType.NAVIGATION_RAIL,
+            )
         },
         containerColor = SwissTransferTheme.colors.navigationItemBackground
     ) {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/received/ReceivedScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/received/ReceivedScreen.kt
@@ -25,8 +25,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.infomaniak.swisstransfer.ui.components.MainScreenFab
-import com.infomaniak.swisstransfer.ui.components.MainScreenFabType
+import com.infomaniak.swisstransfer.ui.components.NewTransferFab
+import com.infomaniak.swisstransfer.ui.components.NewTransferFabType
 import com.infomaniak.swisstransfer.ui.screen.main.LocalNavType
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.PreviewMobile
@@ -41,7 +41,7 @@ fun ReceivedScreen(navigateToDetails: (transferId: Int) -> Unit) {
 private fun ReceivedScreen(navType: NavigationSuiteType) {
     Scaffold(
         floatingActionButton = {
-            if (navType == NavigationSuiteType.NavigationBar) MainScreenFab(mainScreenFabType = MainScreenFabType.BOTTOM_BAR)
+            if (navType == NavigationSuiteType.NavigationBar) NewTransferFab(newTransferFabType = NewTransferFabType.BOTTOM_BAR)
         }
     ) { contentPadding ->
         Text(

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/received/ReceivedScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/received/ReceivedScreen.kt
@@ -18,10 +18,55 @@
 
 package com.infomaniak.swisstransfer.ui.screen.main.received
 
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.infomaniak.swisstransfer.ui.components.MainScreenFab
+import com.infomaniak.swisstransfer.ui.components.MainScreenFabType
+import com.infomaniak.swisstransfer.ui.screen.main.LocalNavType
+import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
+import com.infomaniak.swisstransfer.ui.utils.PreviewMobile
+import com.infomaniak.swisstransfer.ui.utils.PreviewTablet
 
 @Composable
 fun ReceivedScreen(navigateToDetails: (transferId: Int) -> Unit) {
-    Text("Received screen")
+    ReceivedScreen(navType = LocalNavType.current)
+}
+
+@Composable
+private fun ReceivedScreen(navType: NavigationSuiteType) {
+    Scaffold(
+        floatingActionButton = {
+            if (navType == NavigationSuiteType.NavigationBar) MainScreenFab(mainScreenFabType = MainScreenFabType.BOTTOM_BAR)
+        }
+    ) { contentPadding ->
+        Text(
+            text = "Received screen",
+            modifier = Modifier.padding(contentPadding),
+        )
+    }
+}
+
+@PreviewMobile
+@Composable
+private fun ReceivedScreenMobilePreview() {
+    SwissTransferTheme {
+        Surface {
+            ReceivedScreen(navType = NavigationSuiteType.NavigationBar)
+        }
+    }
+}
+
+@PreviewTablet
+@Composable
+private fun ReceivedScreenTabletPreview() {
+    SwissTransferTheme {
+        Surface {
+            ReceivedScreen(navType = NavigationSuiteType.NavigationRail)
+        }
+    }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
@@ -24,11 +24,13 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.components.NewTransferFab
@@ -42,17 +44,20 @@ import com.infomaniak.swisstransfer.ui.utils.PreviewTablet
 @Composable
 fun SentScreen(
     navigateToDetails: (transferId: Int) -> Unit,
+    sentViewModel: SentViewModel = viewModel<SentViewModel>(),
 ) {
-    val viewmodel = viewModel<SentViewModel>()
+    val transfers by sentViewModel.transfers.collectAsStateWithLifecycle()
     SentScreen(
-        isEmpty = viewmodel.transfers.isEmpty(),
+        transfers = transfers,
         navType = LocalNavType.current,
     )
 }
 
 @Composable
-private fun SentScreen(isEmpty: Boolean, navType: NavigationSuiteType) {
-    if (isEmpty) {
+private fun SentScreen(transfers: List<Any>?, navType: NavigationSuiteType) {
+    if (transfers == null) return
+
+    if (transfers.isEmpty()) {
         EmptyScreen()
     } else {
         TransferScreen(navType)
@@ -108,7 +113,7 @@ private fun SentScreenMobilePreview() {
     SwissTransferTheme {
         Surface {
             SentScreen(
-                isEmpty = true,
+                transfers = emptyList(),
                 navType = NavigationSuiteType.NavigationBar,
             )
         }
@@ -121,7 +126,7 @@ private fun SentScreenTabletPreview() {
     SwissTransferTheme {
         Surface {
             SentScreen(
-                isEmpty = true,
+                transfers = emptyList(),
                 navType = NavigationSuiteType.NavigationRail,
             )
         }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
@@ -73,10 +73,9 @@ fun EmptyScreen() {
             style = SwissTransferTheme.typography.specificMedium32,
             textAlign = TextAlign.Center,
         )
+        Spacer(modifier = Modifier.height(Margin.Medium))
         Text(
-            modifier = Modifier
-                .widthIn(max = maxWidth)
-                .padding(top = Margin.Medium),
+            modifier = Modifier.widthIn(max = maxWidth),
             text = stringResource(id = R.string.firstTransferDescription),
             style = SwissTransferTheme.typography.bodyRegular
         )

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
@@ -21,9 +21,11 @@ package com.infomaniak.swisstransfer.ui.screen.main.sent
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.infomaniak.swisstransfer.ui.components.MainScreenFab
+import com.infomaniak.swisstransfer.ui.screen.main.LocalNavType
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.PreviewMobile
 import com.infomaniak.swisstransfer.ui.utils.PreviewTablet
@@ -33,7 +35,15 @@ fun SentScreen(
     navigateToDetails: (transferId: Int) -> Unit,
     navigateToNewTransfer: () -> Unit,
 ) {
-    Scaffold(floatingActionButton = { MainScreenFab(navigateToNewTransfer) }) { contentPadding ->
+    TransferScreen(navType = LocalNavType.current, navigateToNewTransfer)
+}
+
+@Composable
+private fun TransferScreen(
+    navType: NavigationSuiteType,
+    navigateToNewTransfer: () -> Unit,
+) {
+    Scaffold(floatingActionButton = { MainScreenFab(navType, navigateToNewTransfer) }) { contentPadding ->
         Text(
             text = "Sent screen",
             modifier = Modifier.padding(contentPadding),
@@ -42,12 +52,22 @@ fun SentScreen(
 }
 
 @PreviewMobile
+@Composable
+private fun SentScreenMobilePreview() {
+    SwissTransferTheme {
+        TransferScreen(
+            NavigationSuiteType.NavigationBar,
+            navigateToNewTransfer = {},
+        )
+    }
+}
+
 @PreviewTablet
 @Composable
-private fun SentScreenPreview() {
+private fun SentScreenTabletPreview() {
     SwissTransferTheme {
-        SentScreen(
-            navigateToDetails = {},
+        TransferScreen(
+            NavigationSuiteType.NavigationRail,
             navigateToNewTransfer = {},
         )
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
@@ -31,8 +31,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.infomaniak.swisstransfer.R
-import com.infomaniak.swisstransfer.ui.components.MainScreenFab
-import com.infomaniak.swisstransfer.ui.components.MainScreenFabType
+import com.infomaniak.swisstransfer.ui.components.NewTransferFab
+import com.infomaniak.swisstransfer.ui.components.NewTransferFabType
 import com.infomaniak.swisstransfer.ui.screen.main.LocalNavType
 import com.infomaniak.swisstransfer.ui.theme.Margin
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
@@ -80,9 +80,9 @@ fun EmptyScreen() {
             text = stringResource(id = R.string.firstTransferDescription),
             style = SwissTransferTheme.typography.bodyRegular
         )
-        MainScreenFab(
+        NewTransferFab(
             modifier = Modifier.padding(top = Margin.ExtraLarge),
-            mainScreenFabType = MainScreenFabType.EMPTY_STATE,
+            newTransferFabType = NewTransferFabType.EMPTY_STATE,
         )
     }
 }
@@ -93,7 +93,7 @@ private fun TransferScreen(
 ) {
     Scaffold(
         floatingActionButton = {
-            if (navType == NavigationSuiteType.NavigationBar) MainScreenFab(mainScreenFabType = MainScreenFabType.BOTTOM_BAR)
+            if (navType == NavigationSuiteType.NavigationBar) NewTransferFab(newTransferFabType = NewTransferFabType.BOTTOM_BAR)
         }
     ) { contentPadding ->
         Text(

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
@@ -18,15 +18,21 @@
 
 package com.infomaniak.swisstransfer.ui.screen.main.sent
 
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.infomaniak.swisstransfer.ui.components.MainScreenFab
 import com.infomaniak.swisstransfer.ui.components.MainScreenFabType
 import com.infomaniak.swisstransfer.ui.screen.main.LocalNavType
+import com.infomaniak.swisstransfer.ui.theme.Margin
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.PreviewMobile
 import com.infomaniak.swisstransfer.ui.utils.PreviewTablet
@@ -35,7 +41,40 @@ import com.infomaniak.swisstransfer.ui.utils.PreviewTablet
 fun SentScreen(
     navigateToDetails: (transferId: Int) -> Unit,
 ) {
-    TransferScreen(navType = LocalNavType.current)
+    val viewmodel = viewModel<SentViewModel>()
+    if (viewmodel.transfers.isNotEmpty()) {
+        TransferScreen(navType = LocalNavType.current)
+    } else {
+        EmptyScreen()
+    }
+}
+
+@Composable
+fun EmptyScreen() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        val maxWidth = 300.dp
+        Text(
+            modifier = Modifier.widthIn(max = maxWidth),
+            text = "Notre histoire commence ici",
+            style = SwissTransferTheme.typography.specificMedium32,
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            modifier = Modifier
+                .widthIn(max = maxWidth)
+                .padding(top = Margin.Medium),
+            text = "Fait ton premier transfert !",
+            style = SwissTransferTheme.typography.bodyRegular
+        )
+        MainScreenFab(
+            modifier = Modifier.padding(top = Margin.ExtraLarge),
+            mainScreenFabType = MainScreenFabType.EMPTY_STATE,
+        )
+    }
 }
 
 @Composable
@@ -71,5 +110,16 @@ private fun SentScreenTabletPreview() {
         TransferScreen(
             NavigationSuiteType.NavigationRail,
         )
+    }
+}
+
+@PreviewMobile
+@PreviewTablet
+@Composable
+private fun SentScreenPreview() {
+    SwissTransferTheme {
+        Surface {
+            SentScreen({})
+        }
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
@@ -18,13 +18,37 @@
 
 package com.infomaniak.swisstransfer.ui.screen.main.sent
 
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import com.infomaniak.swisstransfer.ui.screen.main.LocalNavType
+import androidx.compose.ui.Modifier
+import com.infomaniak.swisstransfer.ui.components.MainScreenFab
+import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
+import com.infomaniak.swisstransfer.ui.utils.PreviewMobile
+import com.infomaniak.swisstransfer.ui.utils.PreviewTablet
 
 @Composable
-fun SentScreen(navigateToDetails: (transferId: Int) -> Unit) {
-    val navType = LocalNavType.current
+fun SentScreen(
+    navigateToDetails: (transferId: Int) -> Unit,
+    navigateToNewTransfer: () -> Unit,
+) {
+    Scaffold(floatingActionButton = { MainScreenFab(navigateToNewTransfer) }) { contentPadding ->
+        Text(
+            text = "Sent screen",
+            modifier = Modifier.padding(contentPadding),
+        )
+    }
+}
 
-    Text("Sent screen $navType")
+@PreviewMobile
+@PreviewTablet
+@Composable
+private fun SentScreenPreview() {
+    SwissTransferTheme {
+        SentScreen(
+            navigateToDetails = {},
+            navigateToNewTransfer = {},
+        )
+    }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
@@ -26,9 +26,11 @@ import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.components.MainScreenFab
 import com.infomaniak.swisstransfer.ui.components.MainScreenFabType
 import com.infomaniak.swisstransfer.ui.screen.main.LocalNavType
@@ -42,10 +44,18 @@ fun SentScreen(
     navigateToDetails: (transferId: Int) -> Unit,
 ) {
     val viewmodel = viewModel<SentViewModel>()
-    if (viewmodel.transfers.isNotEmpty()) {
-        TransferScreen(navType = LocalNavType.current)
-    } else {
+    SentScreen(
+        isEmpty = viewmodel.transfers.isEmpty(),
+        navType = LocalNavType.current,
+    )
+}
+
+@Composable
+private fun SentScreen(isEmpty: Boolean, navType: NavigationSuiteType) {
+    if (isEmpty) {
         EmptyScreen()
+    } else {
+        TransferScreen(navType)
     }
 }
 
@@ -59,7 +69,7 @@ fun EmptyScreen() {
         val maxWidth = 300.dp
         Text(
             modifier = Modifier.widthIn(max = maxWidth),
-            text = "Notre histoire commence ici",
+            text = stringResource(id = R.string.sentEmptyTitle),
             style = SwissTransferTheme.typography.specificMedium32,
             textAlign = TextAlign.Center,
         )
@@ -67,7 +77,7 @@ fun EmptyScreen() {
             modifier = Modifier
                 .widthIn(max = maxWidth)
                 .padding(top = Margin.Medium),
-            text = "Fait ton premier transfert !",
+            text = stringResource(id = R.string.firstTransferDescription),
             style = SwissTransferTheme.typography.bodyRegular
         )
         MainScreenFab(
@@ -97,9 +107,12 @@ private fun TransferScreen(
 @Composable
 private fun SentScreenMobilePreview() {
     SwissTransferTheme {
-        TransferScreen(
-            NavigationSuiteType.NavigationBar,
-        )
+        Surface {
+            SentScreen(
+                isEmpty = true,
+                navType = NavigationSuiteType.NavigationBar,
+            )
+        }
     }
 }
 
@@ -107,19 +120,11 @@ private fun SentScreenMobilePreview() {
 @Composable
 private fun SentScreenTabletPreview() {
     SwissTransferTheme {
-        TransferScreen(
-            NavigationSuiteType.NavigationRail,
-        )
-    }
-}
-
-@PreviewMobile
-@PreviewTablet
-@Composable
-private fun SentScreenPreview() {
-    SwissTransferTheme {
         Surface {
-            SentScreen({})
+            SentScreen(
+                isEmpty = true,
+                navType = NavigationSuiteType.NavigationRail,
+            )
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.infomaniak.swisstransfer.ui.components.MainScreenFab
+import com.infomaniak.swisstransfer.ui.components.MainScreenFabType
 import com.infomaniak.swisstransfer.ui.screen.main.LocalNavType
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.PreviewMobile
@@ -33,17 +34,19 @@ import com.infomaniak.swisstransfer.ui.utils.PreviewTablet
 @Composable
 fun SentScreen(
     navigateToDetails: (transferId: Int) -> Unit,
-    navigateToNewTransfer: () -> Unit,
 ) {
-    TransferScreen(navType = LocalNavType.current, navigateToNewTransfer)
+    TransferScreen(navType = LocalNavType.current)
 }
 
 @Composable
 private fun TransferScreen(
     navType: NavigationSuiteType,
-    navigateToNewTransfer: () -> Unit,
 ) {
-    Scaffold(floatingActionButton = { MainScreenFab(navType, navigateToNewTransfer) }) { contentPadding ->
+    Scaffold(
+        floatingActionButton = {
+            if (navType == NavigationSuiteType.NavigationBar) MainScreenFab(mainScreenFabType = MainScreenFabType.BOTTOM_BAR)
+        }
+    ) { contentPadding ->
         Text(
             text = "Sent screen",
             modifier = Modifier.padding(contentPadding),
@@ -57,7 +60,6 @@ private fun SentScreenMobilePreview() {
     SwissTransferTheme {
         TransferScreen(
             NavigationSuiteType.NavigationBar,
-            navigateToNewTransfer = {},
         )
     }
 }
@@ -68,7 +70,6 @@ private fun SentScreenTabletPreview() {
     SwissTransferTheme {
         TransferScreen(
             NavigationSuiteType.NavigationRail,
-            navigateToNewTransfer = {},
         )
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentViewModel.kt
@@ -1,0 +1,25 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.infomaniak.swisstransfer.ui.screen.main.sent
+
+import androidx.lifecycle.ViewModel
+
+class SentViewModel: ViewModel() {
+    val transfers = emptyList<Any>()
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentViewModel.kt
@@ -19,7 +19,11 @@
 package com.infomaniak.swisstransfer.ui.screen.main.sent
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
 
-class SentViewModel: ViewModel() {
-    val transfers = emptyList<Any>()
+class SentViewModel : ViewModel() {
+    val transfers = flow<List<Any>> { emit(emptyList()) }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/utils/ContextExt.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/utils/ContextExt.kt
@@ -1,0 +1,30 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.infomaniak.swisstransfer.ui.utils
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import kotlin.reflect.KClass
+
+
+fun <T : Activity> Context.launchActivity(kClass: KClass<T>, options: Bundle? = null) {
+    startActivity(Intent(this, kClass.java), options)
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -16,7 +16,10 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <resources>
+    <string name="contentDescriptionCreateNewTransferButton">New transfer</string>
+    <string name="firstTransferDescription">Make your first transfer!</string>
     <string name="receivedTitle">Received</string>
+    <string name="sentEmptyTitle">Our story begins here</string>
     <string name="sentTitle">Sent</string>
     <string name="settingsTitle">Settings</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -16,7 +16,10 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <resources>
+    <string name="contentDescriptionCreateNewTransferButton">New transfer</string>
+    <string name="firstTransferDescription">Make your first transfer!</string>
     <string name="receivedTitle">Received</string>
+    <string name="sentEmptyTitle">Our story begins here</string>
     <string name="sentTitle">Sent</string>
     <string name="settingsTitle">Settings</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -16,7 +16,10 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <resources>
+    <string name="contentDescriptionCreateNewTransferButton">Nouveau transfert</string>
+    <string name="firstTransferDescription">Fais ton premier transfert !</string>
     <string name="receivedTitle">Recu</string>
+    <string name="sentEmptyTitle">Notre histoire commence ici</string>
     <string name="sentTitle">Envoyé</string>
     <string name="settingsTitle">Paramètres</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -16,7 +16,10 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <resources>
+    <string name="contentDescriptionCreateNewTransferButton">New transfer</string>
+    <string name="firstTransferDescription">Make your first transfer!</string>
     <string name="receivedTitle">Received</string>
+    <string name="sentEmptyTitle">Our story begins here</string>
     <string name="sentTitle">Sent</string>
     <string name="settingsTitle">Settings</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,10 @@
 <resources>
     <string name="appName" translatable="false">SwissTransfer</string>
 
+    <string name="contentDescriptionCreateNewTransferButton">New transfer</string>
+    <string name="firstTransferDescription">Make your first transfer!</string>
     <string name="receivedTitle">Received</string>
+    <string name="sentEmptyTitle">Our story begins here</string>
     <string name="sentTitle">Sent</string>
     <string name="settingsTitle">Settings</string>
 </resources>


### PR DESCRIPTION
Adds the fab in the main screen so it is displayed when needed and navigates to the new transfer activity.

The black arrow pointing to the fab is missing and will be added in a futur PR. 

Depends on #17 