### PR TITLE
Add a scaffold for all the screens that use a top app bar + sticky buttons at the bottom of the screen and some LargeButton component

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/NewTransferActivity.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/NewTransferActivity.kt
@@ -23,6 +23,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.NewTransferScreen
+import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 
 class NewTransferActivity : ComponentActivity() {
 
@@ -30,7 +31,9 @@ class NewTransferActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            NewTransferScreen()
+            SwissTransferTheme {
+                NewTransferScreen()
+            }
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/BottomStickyButtonScaffold.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/BottomStickyButtonScaffold.kt
@@ -29,7 +29,7 @@ fun BottomStickyButtonScaffold(
     topBar: @Composable () -> Unit,
     topButton: @Composable (Modifier) -> Unit,
     bottomButton: @Composable (Modifier) -> Unit,
-    content: @Composable () -> Unit,
+    content: @Composable BoxScope.() -> Unit,
 ) {
     Scaffold(topBar = topBar) { contentPaddings ->
         Column(
@@ -37,9 +37,7 @@ fun BottomStickyButtonScaffold(
                 .fillMaxWidth()
                 .padding(contentPaddings)
         ) {
-            Box(modifier = Modifier.weight(1f)) {
-                content()
-            }
+            Box(modifier = Modifier.weight(1f), content = content)
             DoubleButtonCombo(topButton, bottomButton)
         }
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/BottomStickyButtonScaffold.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/BottomStickyButtonScaffold.kt
@@ -1,0 +1,83 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.infomaniak.swisstransfer.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.infomaniak.swisstransfer.ui.theme.Margin
+
+@Composable
+fun BottomStickyButtonScaffold(
+    modifier: Modifier = Modifier,
+    topButton: @Composable (Modifier) -> Unit,
+    bottomButton: @Composable (Modifier) -> Unit,
+    content: @Composable () -> Unit,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Box(modifier = Modifier.weight(1f)) {
+            content()
+        }
+        BoxWithConstraints(
+            modifier = Modifier
+                .widthIn(max = 800.dp)
+                .align(Alignment.CenterHorizontally),
+        ) {
+            if (maxWidth < 500.dp) {
+                Column(Modifier.fillMaxWidth()) {
+                    topButton(
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = Margin.Medium)
+                    )
+
+                    Spacer(modifier = Modifier.height(Margin.Medium))
+
+                    bottomButton(
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(start = Margin.Medium, end = Margin.Medium, bottom = Margin.Large)
+                    )
+                }
+            } else {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = Margin.Large),
+                    horizontalArrangement = Arrangement.spacedBy(Margin.Medium),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    topButton(
+                        Modifier
+                            .weight(1f)
+                            .padding(start = Margin.Medium)
+                    )
+
+                    bottomButton(
+                        Modifier
+                            .weight(1f)
+                            .padding(end = Margin.Medium)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/BottomStickyButtonScaffold.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/BottomStickyButtonScaffold.kt
@@ -27,8 +27,8 @@ import androidx.compose.ui.Modifier
 fun BottomStickyButtonScaffold(
     modifier: Modifier = Modifier,
     topBar: @Composable () -> Unit,
-    topButton: @Composable (Modifier) -> Unit,
-    bottomButton: @Composable (Modifier) -> Unit,
+    topButton: @Composable ((Modifier) -> Unit)? = null,
+    bottomButton: @Composable ((Modifier) -> Unit)? = null,
     content: @Composable BoxScope.() -> Unit,
 ) {
     Scaffold(topBar = topBar) { contentPaddings ->

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/BottomStickyButtonScaffold.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/BottomStickyButtonScaffold.kt
@@ -21,10 +21,7 @@ package com.infomaniak.swisstransfer.ui.components
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import com.infomaniak.swisstransfer.ui.theme.Margin
 
 @Composable
 fun BottomStickyButtonScaffold(
@@ -44,56 +41,6 @@ fun BottomStickyButtonScaffold(
                 content()
             }
             DoubleButtonCombo(topButton, bottomButton)
-        }
-    }
-}
-
-@Composable
-private fun ColumnScope.DoubleButtonCombo(
-    topButton: @Composable (Modifier) -> Unit,
-    bottomButton: @Composable (Modifier) -> Unit
-) {
-    BoxWithConstraints(
-        modifier = Modifier
-            .widthIn(max = 800.dp)
-            .align(Alignment.CenterHorizontally),
-    ) {
-        if (maxWidth < 500.dp) {
-            Column(Modifier.fillMaxWidth()) {
-                topButton(
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = Margin.Medium)
-                )
-
-                Spacer(modifier = Modifier.height(Margin.Medium))
-
-                bottomButton(
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(start = Margin.Medium, end = Margin.Medium, bottom = Margin.Large)
-                )
-            }
-        } else {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = Margin.Large),
-                horizontalArrangement = Arrangement.spacedBy(Margin.Medium),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                topButton(
-                    Modifier
-                        .weight(1f)
-                        .padding(start = Margin.Medium)
-                )
-
-                bottomButton(
-                    Modifier
-                        .weight(1f)
-                        .padding(end = Margin.Medium)
-                )
-            }
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/BottomStickyButtonScaffold.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/BottomStickyButtonScaffold.kt
@@ -19,6 +19,7 @@
 package com.infomaniak.swisstransfer.ui.components
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,55 +29,70 @@ import com.infomaniak.swisstransfer.ui.theme.Margin
 @Composable
 fun BottomStickyButtonScaffold(
     modifier: Modifier = Modifier,
+    topBar: @Composable () -> Unit,
     topButton: @Composable (Modifier) -> Unit,
     bottomButton: @Composable (Modifier) -> Unit,
     content: @Composable () -> Unit,
 ) {
-    Column(modifier = modifier.fillMaxWidth()) {
-        Box(modifier = Modifier.weight(1f)) {
-            content()
-        }
-        BoxWithConstraints(
-            modifier = Modifier
-                .widthIn(max = 800.dp)
-                .align(Alignment.CenterHorizontally),
+    Scaffold(topBar = topBar) { contentPaddings ->
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(contentPaddings)
         ) {
-            if (maxWidth < 500.dp) {
-                Column(Modifier.fillMaxWidth()) {
-                    topButton(
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = Margin.Medium)
-                    )
+            Box(modifier = Modifier.weight(1f)) {
+                content()
+            }
+            DoubleButtonCombo(topButton, bottomButton)
+        }
+    }
+}
 
-                    Spacer(modifier = Modifier.height(Margin.Medium))
-
-                    bottomButton(
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(start = Margin.Medium, end = Margin.Medium, bottom = Margin.Large)
-                    )
-                }
-            } else {
-                Row(
-                    modifier = Modifier
+@Composable
+private fun ColumnScope.DoubleButtonCombo(
+    topButton: @Composable (Modifier) -> Unit,
+    bottomButton: @Composable (Modifier) -> Unit
+) {
+    BoxWithConstraints(
+        modifier = Modifier
+            .widthIn(max = 800.dp)
+            .align(Alignment.CenterHorizontally),
+    ) {
+        if (maxWidth < 500.dp) {
+            Column(Modifier.fillMaxWidth()) {
+                topButton(
+                    Modifier
                         .fillMaxWidth()
-                        .padding(bottom = Margin.Large),
-                    horizontalArrangement = Arrangement.spacedBy(Margin.Medium),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    topButton(
-                        Modifier
-                            .weight(1f)
-                            .padding(start = Margin.Medium)
-                    )
+                        .padding(horizontal = Margin.Medium)
+                )
 
-                    bottomButton(
-                        Modifier
-                            .weight(1f)
-                            .padding(end = Margin.Medium)
-                    )
-                }
+                Spacer(modifier = Modifier.height(Margin.Medium))
+
+                bottomButton(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(start = Margin.Medium, end = Margin.Medium, bottom = Margin.Large)
+                )
+            }
+        } else {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = Margin.Large),
+                horizontalArrangement = Arrangement.spacedBy(Margin.Medium),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                topButton(
+                    Modifier
+                        .weight(1f)
+                        .padding(start = Margin.Medium)
+                )
+
+                bottomButton(
+                    Modifier
+                        .weight(1f)
+                        .padding(end = Margin.Medium)
+                )
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/ButtonType.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/ButtonType.kt
@@ -1,0 +1,80 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.infomaniak.swisstransfer.ui.components
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.infomaniak.swisstransfer.ui.theme.Margin
+import com.infomaniak.swisstransfer.ui.theme.Shapes
+import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
+
+@Composable
+fun LargeButton(
+    modifier: Modifier = Modifier,
+    @StringRes titleRes: Int,
+    style: ButtonType,
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+    imageVector: ImageVector? = null,
+) {
+    Button(
+        modifier = modifier.height(56.dp),
+        colors = style.buttonColors(),
+        shape = Shapes.medium,
+        enabled = enabled,
+        onClick = onClick,
+    ) {
+        imageVector?.let {
+            Icon(modifier = Modifier.size(Margin.Medium), imageVector = it, contentDescription = null)
+            Spacer(modifier = Modifier.width(Margin.Small))
+        }
+        Text(text = stringResource(id = titleRes))
+    }
+}
+
+enum class ButtonType(val buttonColors: @Composable () -> ButtonColors) {
+    PRIMARY({
+        ButtonDefaults.buttonColors(
+            containerColor = SwissTransferTheme.materialColors.primary,
+            contentColor = SwissTransferTheme.materialColors.onPrimary,
+        )
+    }),
+    SECONDARY({
+        ButtonDefaults.buttonColors(
+            containerColor = SwissTransferTheme.colors.tertiaryButtonBackground,
+            contentColor = SwissTransferTheme.materialColors.primary,
+        )
+    }),
+    TERTIARY({
+        ButtonDefaults.buttonColors(
+            containerColor = Color.Transparent,
+            contentColor = SwissTransferTheme.materialColors.primary,
+        )
+    }),
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/DoubleButtonCombo.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/DoubleButtonCombo.kt
@@ -25,6 +25,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.infomaniak.swisstransfer.ui.theme.Margin
 
+private val WIDTH_LIMIT = 800.dp
+private val WIDTH_THRESHOLD = 500.dp
+
 @Composable
 fun ColumnScope.DoubleButtonCombo(
     topButton: @Composable (Modifier) -> Unit,
@@ -32,45 +35,52 @@ fun ColumnScope.DoubleButtonCombo(
 ) {
     BoxWithConstraints(
         modifier = Modifier
-            .widthIn(max = 800.dp)
+            .widthIn(max = WIDTH_LIMIT)
             .align(Alignment.CenterHorizontally),
     ) {
-        if (maxWidth < 500.dp) {
-            Column(Modifier.fillMaxWidth()) {
-                topButton(
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = Margin.Medium)
-                )
-
-                Spacer(modifier = Modifier.height(Margin.Medium))
-
-                bottomButton(
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(start = Margin.Medium, end = Margin.Medium, bottom = Margin.Large)
-                )
-            }
+        if (maxWidth < WIDTH_THRESHOLD) {
+            VerticallyStackedButtons(topButton, bottomButton)
         } else {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = Margin.Large),
-                horizontalArrangement = Arrangement.spacedBy(Margin.Medium),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                topButton(
-                    Modifier
-                        .weight(1f)
-                        .padding(start = Margin.Medium)
-                )
-
-                bottomButton(
-                    Modifier
-                        .weight(1f)
-                        .padding(end = Margin.Medium)
-                )
-            }
+            HorizontallyStackedButtons(topButton, bottomButton)
         }
+    }
+}
+
+@Composable
+private fun VerticallyStackedButtons(
+    topButton: @Composable (Modifier) -> Unit,
+    bottomButton: @Composable (Modifier) -> Unit
+) {
+    Column(Modifier.fillMaxWidth()) {
+        topButton(
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Margin.Medium)
+        )
+
+        Spacer(modifier = Modifier.height(Margin.Medium))
+
+        bottomButton(
+            Modifier
+                .fillMaxWidth()
+                .padding(start = Margin.Medium, end = Margin.Medium, bottom = Margin.Large)
+        )
+    }
+}
+
+@Composable
+private fun HorizontallyStackedButtons(
+    topButton: @Composable (Modifier) -> Unit,
+    bottomButton: @Composable (Modifier) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = Margin.Large, start = Margin.Medium, end = Margin.Medium),
+        horizontalArrangement = Arrangement.spacedBy(Margin.Medium),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        topButton(Modifier.weight(1f))
+        bottomButton(Modifier.weight(1f))
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/DoubleButtonCombo.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/DoubleButtonCombo.kt
@@ -30,18 +30,24 @@ private val WIDTH_THRESHOLD = 500.dp
 
 @Composable
 fun ColumnScope.DoubleButtonCombo(
-    topButton: @Composable (Modifier) -> Unit,
-    bottomButton: @Composable (Modifier) -> Unit
+    topButton: @Composable ((Modifier) -> Unit)? = null,
+    bottomButton: @Composable ((Modifier) -> Unit)? = null
 ) {
     BoxWithConstraints(
         modifier = Modifier
             .widthIn(max = WIDTH_LIMIT)
             .align(Alignment.CenterHorizontally),
     ) {
-        if (maxWidth < WIDTH_THRESHOLD) {
-            VerticallyStackedButtons(topButton, bottomButton)
-        } else {
-            HorizontallyStackedButtons(topButton, bottomButton)
+        when {
+            topButton == null && bottomButton == null -> Unit
+            topButton != null && bottomButton != null -> {
+                if (maxWidth < WIDTH_THRESHOLD) {
+                    VerticallyStackedButtons(topButton, bottomButton)
+                } else {
+                    HorizontallyStackedButtons(topButton, bottomButton)
+                }
+            }
+            else -> SingleButton(button = topButton ?: bottomButton!!)
         }
     }
 }
@@ -83,4 +89,14 @@ private fun HorizontallyStackedButtons(
         topButton(Modifier.weight(1f))
         bottomButton(Modifier.weight(1f))
     }
+}
+
+@Composable
+private fun SingleButton(button: @Composable (Modifier) -> Unit) {
+    button(
+        Modifier
+            .fillMaxWidth()
+            .widthIn(WIDTH_LIMIT / 2)
+            .padding(bottom = Margin.Large, start = Margin.Medium, end = Margin.Medium),
+    )
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/DoubleButtonCombo.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/DoubleButtonCombo.kt
@@ -1,0 +1,76 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.infomaniak.swisstransfer.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.infomaniak.swisstransfer.ui.theme.Margin
+
+@Composable
+fun ColumnScope.DoubleButtonCombo(
+    topButton: @Composable (Modifier) -> Unit,
+    bottomButton: @Composable (Modifier) -> Unit
+) {
+    BoxWithConstraints(
+        modifier = Modifier
+            .widthIn(max = 800.dp)
+            .align(Alignment.CenterHorizontally),
+    ) {
+        if (maxWidth < 500.dp) {
+            Column(Modifier.fillMaxWidth()) {
+                topButton(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = Margin.Medium)
+                )
+
+                Spacer(modifier = Modifier.height(Margin.Medium))
+
+                bottomButton(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(start = Margin.Medium, end = Margin.Medium, bottom = Margin.Large)
+                )
+            }
+        } else {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = Margin.Large),
+                horizontalArrangement = Arrangement.spacedBy(Margin.Medium),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                topButton(
+                    Modifier
+                        .weight(1f)
+                        .padding(start = Margin.Medium)
+                )
+
+                bottomButton(
+                    Modifier
+                        .weight(1f)
+                        .padding(end = Margin.Medium)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/LargeButton.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/LargeButton.kt
@@ -18,18 +18,20 @@
 
 package com.infomaniak.swisstransfer.ui.components
 
+import android.content.res.Configuration
 import androidx.annotation.StringRes
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.infomaniak.swisstransfer.R
+import com.infomaniak.swisstransfer.ui.icons.AppIcons
+import com.infomaniak.swisstransfer.ui.icons.app.Add
 import com.infomaniak.swisstransfer.ui.theme.Margin
 import com.infomaniak.swisstransfer.ui.theme.Shapes
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
@@ -38,7 +40,7 @@ import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 fun LargeButton(
     modifier: Modifier = Modifier,
     @StringRes titleRes: Int,
-    style: ButtonType,
+    style: ButtonType = ButtonType.PRIMARY,
     enabled: Boolean = true,
     onClick: () -> Unit,
     imageVector: ImageVector? = null,
@@ -77,4 +79,33 @@ enum class ButtonType(val buttonColors: @Composable () -> ButtonColors) {
             contentColor = SwissTransferTheme.materialColors.primary,
         )
     }),
+}
+
+@Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)
+@Composable
+private fun LargeButtonPreview() {
+    SwissTransferTheme {
+        Column {
+            LargeButton(
+                titleRes = R.string.appName,
+                imageVector = AppIcons.Add,
+                onClick = {},
+            )
+            Spacer(modifier = Modifier.height(Margin.Small))
+            LargeButton(
+                titleRes = R.string.appName,
+                imageVector = AppIcons.Add,
+                style = ButtonType.SECONDARY,
+                onClick = {},
+            )
+            Spacer(modifier = Modifier.height(Margin.Small))
+            LargeButton(
+                titleRes = R.string.appName,
+                imageVector = AppIcons.Add,
+                style = ButtonType.TERTIARY,
+                onClick = {},
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/LargeButton.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/LargeButton.kt
@@ -20,6 +20,7 @@ package com.infomaniak.swisstransfer.ui.components
 
 import android.content.res.Configuration
 import androidx.annotation.StringRes
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -81,31 +82,21 @@ enum class ButtonType(val buttonColors: @Composable () -> ButtonColors) {
     }),
 }
 
-@Preview
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)
+@Preview(name = "Light")
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)
 @Composable
 private fun LargeButtonPreview() {
     SwissTransferTheme {
-        Column {
-            LargeButton(
-                titleRes = R.string.appName,
-                imageVector = AppIcons.Add,
-                onClick = {},
-            )
-            Spacer(modifier = Modifier.height(Margin.Small))
-            LargeButton(
-                titleRes = R.string.appName,
-                imageVector = AppIcons.Add,
-                style = ButtonType.SECONDARY,
-                onClick = {},
-            )
-            Spacer(modifier = Modifier.height(Margin.Small))
-            LargeButton(
-                titleRes = R.string.appName,
-                imageVector = AppIcons.Add,
-                style = ButtonType.TERTIARY,
-                onClick = {},
-            )
+        Column(modifier = Modifier.background(SwissTransferTheme.materialColors.background)) {
+            ButtonType.entries.forEach {
+                LargeButton(
+                    titleRes = R.string.appName,
+                    style = it,
+                    imageVector = AppIcons.Add,
+                    onClick = {},
+                )
+                Spacer(modifier = Modifier.height(Margin.Small))
+            }
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferTobAppBar.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferTobAppBar.kt
@@ -1,0 +1,41 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.infomaniak.swisstransfer.ui.components
+
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun SwissTransferTobAppBar() {
+    CenterAlignedTopAppBar(
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = SwissTransferTheme.materialColors.tertiary,
+            titleContentColor = Color.White, // TODO
+        ),
+        title = {
+            Text("Title")
+        }
+    )
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -75,6 +75,7 @@ private fun LargeButton(
     modifier: Modifier = Modifier,
     @StringRes titleRes: Int,
     style: ButtonType,
+    enabled: Boolean = true,
     onClick: () -> Unit,
     imageVector: ImageVector? = null,
 ) {
@@ -82,6 +83,7 @@ private fun LargeButton(
         modifier = modifier.height(56.dp),
         colors = style.buttonColors(),
         shape = Shapes.medium,
+        enabled = enabled,
         onClick = onClick,
     ) {
         imageVector?.let {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -39,7 +39,7 @@ fun ImportFilesScreen() {
         topButton = { modifier ->
             LargeButton(
                 modifier = modifier,
-                titleRes = R.string.appName,
+                titleRes = R.string.buttonAddFiles,
                 imageVector = AppIcons.Add,
                 style = ButtonType.TERTIARY,
                 onClick = { /*TODO*/ },
@@ -48,7 +48,7 @@ fun ImportFilesScreen() {
         bottomButton = { modifier ->
             LargeButton(
                 modifier = modifier,
-                titleRes = R.string.appName,
+                titleRes = R.string.buttonNext,
                 style = ButtonType.PRIMARY,
                 onClick = { /*TODO*/ },
             )

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -49,7 +49,6 @@ fun ImportFilesScreen() {
             LargeButton(
                 modifier = modifier,
                 titleRes = R.string.buttonNext,
-                style = ButtonType.PRIMARY,
                 onClick = { /*TODO*/ },
             )
         },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -18,10 +18,106 @@
 
 package com.infomaniak.swisstransfer.ui.screen.newtransfer.importfiles
 
-import androidx.compose.material3.Text
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.infomaniak.swisstransfer.R
+import com.infomaniak.swisstransfer.ui.components.BottomStickyButtonScaffold
+import com.infomaniak.swisstransfer.ui.components.SwissTransferTobAppBar
+import com.infomaniak.swisstransfer.ui.icons.AppIcons
+import com.infomaniak.swisstransfer.ui.icons.app.Add
+import com.infomaniak.swisstransfer.ui.theme.Margin
+import com.infomaniak.swisstransfer.ui.theme.Shapes
+import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
+import com.infomaniak.swisstransfer.ui.utils.PreviewMobile
+import com.infomaniak.swisstransfer.ui.utils.PreviewTablet
 
 @Composable
 fun ImportFilesScreen() {
-    Text("ImportFilesScreen")
+    Scaffold(
+        topBar = { SwissTransferTobAppBar() },
+    ) { contentPaddings ->
+        BottomStickyButtonScaffold(
+            modifier = Modifier.padding(contentPaddings),
+            topButton = { modifier ->
+                LargeButton(
+                    modifier = modifier,
+                    titleRes = R.string.appName,
+                    imageVector = AppIcons.Add,
+                    style = ButtonType.TERTIARY,
+                    onClick = {},
+                )
+            },
+            bottomButton = { modifier ->
+                LargeButton(
+                    modifier = modifier,
+                    titleRes = R.string.appName,
+                    style = ButtonType.PRIMARY,
+                    onClick = {},
+                )
+            },
+        ) {
+            Column {
+                Text("ImportFilesScreen")
+            }
+        }
+    }
+}
+
+@Composable
+private fun LargeButton(
+    modifier: Modifier = Modifier,
+    @StringRes titleRes: Int,
+    style: ButtonType,
+    onClick: () -> Unit,
+    imageVector: ImageVector? = null,
+) {
+    Button(
+        modifier = modifier.height(56.dp),
+        colors = style.buttonColors(),
+        shape = Shapes.medium,
+        onClick = onClick,
+    ) {
+        imageVector?.let {
+            Icon(modifier = Modifier.size(Margin.Medium), imageVector = it, contentDescription = null)
+            Spacer(modifier = Modifier.width(Margin.Small))
+        }
+        Text(text = stringResource(id = titleRes))
+    }
+}
+
+enum class ButtonType(val buttonColors: @Composable () -> ButtonColors) {
+    PRIMARY({
+        ButtonDefaults.buttonColors(
+            containerColor = SwissTransferTheme.materialColors.primary,
+            contentColor = SwissTransferTheme.materialColors.onPrimary,
+        )
+    }),
+    SECONDARY({
+        ButtonDefaults.buttonColors(
+            containerColor = SwissTransferTheme.colors.tertiaryButtonBackground,
+            contentColor = SwissTransferTheme.materialColors.primary,
+        )
+    }),
+    TERTIARY({
+        ButtonDefaults.buttonColors(
+            containerColor = Color.Transparent,
+            contentColor = SwissTransferTheme.materialColors.primary,
+        )
+    }),
+}
+
+@PreviewMobile
+@PreviewTablet
+@Composable
+private fun ImportFilesScreenPreview() {
+    SwissTransferTheme {
+        ImportFilesScreen()
+    }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -18,22 +18,16 @@
 
 package com.infomaniak.swisstransfer.ui.screen.newtransfer.importfiles
 
-import androidx.annotation.StringRes
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.components.BottomStickyButtonScaffold
+import com.infomaniak.swisstransfer.ui.components.ButtonType
+import com.infomaniak.swisstransfer.ui.components.LargeButton
 import com.infomaniak.swisstransfer.ui.components.SwissTransferTobAppBar
 import com.infomaniak.swisstransfer.ui.icons.AppIcons
 import com.infomaniak.swisstransfer.ui.icons.app.Add
-import com.infomaniak.swisstransfer.ui.theme.Margin
-import com.infomaniak.swisstransfer.ui.theme.Shapes
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.PreviewMobile
 import com.infomaniak.swisstransfer.ui.utils.PreviewTablet
@@ -48,7 +42,7 @@ fun ImportFilesScreen() {
                 titleRes = R.string.appName,
                 imageVector = AppIcons.Add,
                 style = ButtonType.TERTIARY,
-                onClick = {},
+                onClick = { /*TODO*/ },
             )
         },
         bottomButton = { modifier ->
@@ -56,7 +50,7 @@ fun ImportFilesScreen() {
                 modifier = modifier,
                 titleRes = R.string.appName,
                 style = ButtonType.PRIMARY,
-                onClick = {},
+                onClick = { /*TODO*/ },
             )
         },
     ) {
@@ -64,51 +58,6 @@ fun ImportFilesScreen() {
             Text("ImportFilesScreen")
         }
     }
-}
-
-@Composable
-private fun LargeButton(
-    modifier: Modifier = Modifier,
-    @StringRes titleRes: Int,
-    style: ButtonType,
-    enabled: Boolean = true,
-    onClick: () -> Unit,
-    imageVector: ImageVector? = null,
-) {
-    Button(
-        modifier = modifier.height(56.dp),
-        colors = style.buttonColors(),
-        shape = Shapes.medium,
-        enabled = enabled,
-        onClick = onClick,
-    ) {
-        imageVector?.let {
-            Icon(modifier = Modifier.size(Margin.Medium), imageVector = it, contentDescription = null)
-            Spacer(modifier = Modifier.width(Margin.Small))
-        }
-        Text(text = stringResource(id = titleRes))
-    }
-}
-
-enum class ButtonType(val buttonColors: @Composable () -> ButtonColors) {
-    PRIMARY({
-        ButtonDefaults.buttonColors(
-            containerColor = SwissTransferTheme.materialColors.primary,
-            contentColor = SwissTransferTheme.materialColors.onPrimary,
-        )
-    }),
-    SECONDARY({
-        ButtonDefaults.buttonColors(
-            containerColor = SwissTransferTheme.colors.tertiaryButtonBackground,
-            contentColor = SwissTransferTheme.materialColors.primary,
-        )
-    }),
-    TERTIARY({
-        ButtonDefaults.buttonColors(
-            containerColor = Color.Transparent,
-            contentColor = SwissTransferTheme.materialColors.primary,
-        )
-    }),
 }
 
 @PreviewMobile

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -40,32 +40,28 @@ import com.infomaniak.swisstransfer.ui.utils.PreviewTablet
 
 @Composable
 fun ImportFilesScreen() {
-    Scaffold(
+    BottomStickyButtonScaffold(
         topBar = { SwissTransferTobAppBar() },
-    ) { contentPaddings ->
-        BottomStickyButtonScaffold(
-            modifier = Modifier.padding(contentPaddings),
-            topButton = { modifier ->
-                LargeButton(
-                    modifier = modifier,
-                    titleRes = R.string.appName,
-                    imageVector = AppIcons.Add,
-                    style = ButtonType.TERTIARY,
-                    onClick = {},
-                )
-            },
-            bottomButton = { modifier ->
-                LargeButton(
-                    modifier = modifier,
-                    titleRes = R.string.appName,
-                    style = ButtonType.PRIMARY,
-                    onClick = {},
-                )
-            },
-        ) {
-            Column {
-                Text("ImportFilesScreen")
-            }
+        topButton = { modifier ->
+            LargeButton(
+                modifier = modifier,
+                titleRes = R.string.appName,
+                imageVector = AppIcons.Add,
+                style = ButtonType.TERTIARY,
+                onClick = {},
+            )
+        },
+        bottomButton = { modifier ->
+            LargeButton(
+                modifier = modifier,
+                titleRes = R.string.appName,
+                style = ButtonType.PRIMARY,
+                onClick = {},
+            )
+        },
+    ) {
+        Column {
+            Text("ImportFilesScreen")
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/ColorDark.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/ColorDark.kt
@@ -57,4 +57,5 @@ val CustomDarkColorScheme = CustomColorScheme(
     secondaryTextColor = Color(shark),
     navigationItemBackground = Color(dark2),
     divider = Color(dark3),
+    tertiaryButtonBackground = Color(dark2),
 )

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/ColorLight.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/ColorLight.kt
@@ -32,6 +32,7 @@ private const val elephant = 0xFF666666
 private const val shark = 0xFF9F9F9F
 private const val mouse = 0xFFE0E0E0
 private const val polar_bear = 0xFFF5F5F5
+private const val rabbit = 0xFFF1F1F1
 
 private const val specific1 = 0xFFD8F0E3
 private const val specific2 = 0xFFCCDBDE
@@ -62,4 +63,5 @@ val CustomLightColorScheme = CustomColorScheme(
     secondaryTextColor = Color(elephant),
     navigationItemBackground = LightColorScheme.background,
     divider = Color(mouse),
+    tertiaryButtonBackground = Color(rabbit),
 )

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/Theme.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/Theme.kt
@@ -65,4 +65,5 @@ data class CustomColorScheme(
     val secondaryTextColor: Color = Color.Unspecified,
     val navigationItemBackground: Color = Color.Unspecified,
     val divider: Color = Color.Unspecified,
+    val tertiaryButtonBackground: Color = Color.Unspecified,
 )

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -16,6 +16,8 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <resources>
+    <string name="buttonAddFiles">Add files</string>
+    <string name="buttonNext">Next</string>
     <string name="contentDescriptionCreateNewTransferButton">New transfer</string>
     <string name="firstTransferDescription">Make your first transfer!</string>
     <string name="receivedTitle">Received</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -16,6 +16,8 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <resources>
+    <string name="buttonAddFiles">Add files</string>
+    <string name="buttonNext">Next</string>
     <string name="contentDescriptionCreateNewTransferButton">New transfer</string>
     <string name="firstTransferDescription">Make your first transfer!</string>
     <string name="receivedTitle">Received</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -16,6 +16,8 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <resources>
+    <string name="buttonAddFiles">Ajouter des fichiers</string>
+    <string name="buttonNext">Suivant</string>
     <string name="contentDescriptionCreateNewTransferButton">Nouveau transfert</string>
     <string name="firstTransferDescription">Fais ton premier transfert !</string>
     <string name="receivedTitle">Recu</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -16,6 +16,8 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <resources>
+    <string name="buttonAddFiles">Add files</string>
+    <string name="buttonNext">Next</string>
     <string name="contentDescriptionCreateNewTransferButton">New transfer</string>
     <string name="firstTransferDescription">Make your first transfer!</string>
     <string name="receivedTitle">Received</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,8 @@
 <resources>
     <string name="appName" translatable="false">SwissTransfer</string>
 
+    <string name="buttonAddFiles">Add files</string>
+    <string name="buttonNext">Next</string>
     <string name="contentDescriptionCreateNewTransferButton">New transfer</string>
     <string name="firstTransferDescription">Make your first transfer!</string>
     <string name="receivedTitle">Received</string>


### PR DESCRIPTION
This way we will always create the screens the same way.

This PR also adds the LargeButton component but later on this LargeButton should be defined with the more normal buttons which share a bunch of characteristics as well