### PR TITLE
Add the top app bar components

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/BrandTobAppBar.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/BrandTobAppBar.kt
@@ -1,0 +1,69 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.infomaniak.swisstransfer.ui.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.infomaniak.swisstransfer.R
+import com.infomaniak.swisstransfer.ui.icons.AppIcons
+import com.infomaniak.swisstransfer.ui.icons.illu.LogoInfomaniak
+import com.infomaniak.swisstransfer.ui.icons.illu.LogoSwissTransfer
+import com.infomaniak.swisstransfer.ui.theme.Margin
+import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
+import com.infomaniak.swisstransfer.ui.utils.PreviewMobile
+import com.infomaniak.swisstransfer.ui.utils.PreviewTablet
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun BrandTobAppBar() {
+    CenterAlignedTopAppBar(
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = SwissTransferTheme.materialColors.tertiary,
+            titleContentColor = SwissTransferTheme.colors.toolbarTextColor,
+        ),
+        title = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Image(imageVector = AppIcons.Illu.LogoInfomaniak, contentDescription = null)
+                Spacer(modifier = Modifier.width(Margin.Medium))
+                VerticalDivider(modifier = Modifier.height(Margin.Large), color = SwissTransferTheme.colors.toolbarTextColor)
+                Spacer(modifier = Modifier.width(Margin.Medium))
+                Image(imageVector = AppIcons.Illu.LogoSwissTransfer, contentDescription = null)
+                Spacer(modifier = Modifier.width(Margin.Small))
+                Text(text = stringResource(id = R.string.appName), color = SwissTransferTheme.colors.toolbarTextColor)
+            }
+        }
+    )
+}
+
+@PreviewMobile
+@PreviewTablet
+@Composable
+private fun BrandTobAppBarPreview() {
+    SwissTransferTheme {
+        BrandTobAppBar()
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferTobAppBar.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferTobAppBar.kt
@@ -18,18 +18,20 @@
 
 package com.infomaniak.swisstransfer.ui.components
 
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
+import com.infomaniak.swisstransfer.ui.utils.PreviewMobile
+import com.infomaniak.swisstransfer.ui.utils.PreviewTablet
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 fun SwissTransferTobAppBar() {
-    CenterAlignedTopAppBar(
+    TopAppBar(
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = SwissTransferTheme.materialColors.tertiary,
             titleContentColor = Color.White, // TODO
@@ -38,4 +40,13 @@ fun SwissTransferTobAppBar() {
             Text("Title")
         }
     )
+}
+
+@PreviewMobile
+@PreviewTablet
+@Composable
+private fun SwissTransferTobAppBarPreview() {
+    SwissTransferTheme {
+        SwissTransferTobAppBar()
+    }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferTobAppBar.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferTobAppBar.kt
@@ -35,7 +35,11 @@ import com.infomaniak.swisstransfer.ui.utils.PreviewTablet
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
-fun SwissTransferTobAppBar(@StringRes titleRes: Int, navigationMenu: TopAppBarMenu? = null, vararg actionMenus: TopAppBarMenu) {
+fun SwissTransferTobAppBar(
+    @StringRes titleRes: Int,
+    navigationMenu: TopAppBarButton? = null,
+    vararg actionMenus: TopAppBarButton
+) {
     TopAppBar(
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = SwissTransferTheme.materialColors.tertiary,
@@ -52,24 +56,24 @@ fun SwissTransferTobAppBar(@StringRes titleRes: Int, navigationMenu: TopAppBarMe
 }
 
 @Composable
-private fun MenuButton(navigationMenu: TopAppBarMenu) {
+private fun MenuButton(navigationMenu: TopAppBarButton) {
     IconButton(onClick = navigationMenu.onClick) {
         Icon(imageVector = navigationMenu.icon, contentDescription = stringResource(navigationMenu.contentDescription))
     }
 }
 
 @Immutable
-data class TopAppBarMenu(
+data class TopAppBarButton(
     val icon: ImageVector,
     @StringRes val contentDescription: Int,
     val onClick: () -> Unit,
 ) {
     companion object {
-        val backButton: (onClick: () -> Unit) -> TopAppBarMenu = {
-            TopAppBarMenu(AppIcons.ArrowLeft, R.string.contentDescriptionButtonBack, it)
+        val backButton: (onClick: () -> Unit) -> TopAppBarButton = {
+            TopAppBarButton(AppIcons.ArrowLeft, R.string.contentDescriptionButtonBack, it)
         }
-        val closeButton: (onClick: () -> Unit) -> TopAppBarMenu = {
-            TopAppBarMenu(AppIcons.Cross, R.string.contentDescriptionButtonClose, it)
+        val closeButton: (onClick: () -> Unit) -> TopAppBarButton = {
+            TopAppBarButton(AppIcons.Cross, R.string.contentDescriptionButtonClose, it)
         }
     }
 }
@@ -80,10 +84,10 @@ data class TopAppBarMenu(
 private fun SwissTransferTobAppBarPreview() {
     SwissTransferTheme {
         SwissTransferTobAppBar(
-            R.string.appName,
-            TopAppBarMenu.backButton {},
-            TopAppBarMenu(AppIcons.Add, R.string.appName) {},
-            TopAppBarMenu.closeButton {}
+            titleRes = R.string.appName,
+            navigationMenu = TopAppBarButton.backButton {},
+            TopAppBarButton(AppIcons.Add, R.string.appName) {},
+            TopAppBarButton.closeButton {}
         )
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferTobAppBar.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferTobAppBar.kt
@@ -54,19 +54,23 @@ fun SwissTransferTobAppBar(@StringRes titleRes: Int, navigationMenu: TopAppBarMe
 @Composable
 private fun MenuButton(navigationMenu: TopAppBarMenu) {
     IconButton(onClick = navigationMenu.onClick) {
-        Icon(imageVector = navigationMenu.icon, contentDescription = navigationMenu.contentDescription)
+        Icon(imageVector = navigationMenu.icon, contentDescription = stringResource(navigationMenu.contentDescription))
     }
 }
 
 @Immutable
 data class TopAppBarMenu(
     val icon: ImageVector,
-    val contentDescription: String?,
+    @StringRes val contentDescription: Int,
     val onClick: () -> Unit,
 ) {
     companion object {
-        val backButton: (onClick: () -> Unit) -> TopAppBarMenu = { TopAppBarMenu(AppIcons.ArrowLeft, null, it) }
-        val closeButton: (onClick: () -> Unit) -> TopAppBarMenu = { TopAppBarMenu(AppIcons.Cross, null, it) }
+        val backButton: (onClick: () -> Unit) -> TopAppBarMenu = {
+            TopAppBarMenu(AppIcons.ArrowLeft, R.string.contentDescriptionButtonBack, it)
+        }
+        val closeButton: (onClick: () -> Unit) -> TopAppBarMenu = {
+            TopAppBarMenu(AppIcons.Cross, R.string.contentDescriptionButtonClose, it)
+        }
     }
 }
 
@@ -78,7 +82,7 @@ private fun SwissTransferTobAppBarPreview() {
         SwissTransferTobAppBar(
             R.string.appName,
             TopAppBarMenu.backButton {},
-            TopAppBarMenu(AppIcons.Add, null, {}),
+            TopAppBarMenu(AppIcons.Add, R.string.appName) {},
             TopAppBarMenu.closeButton {}
         )
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferTobAppBar.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferTobAppBar.kt
@@ -18,28 +18,56 @@
 
 package com.infomaniak.swisstransfer.ui.components
 
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
+import androidx.annotation.StringRes
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import com.infomaniak.swisstransfer.R
+import com.infomaniak.swisstransfer.ui.icons.AppIcons
+import com.infomaniak.swisstransfer.ui.icons.app.Add
+import com.infomaniak.swisstransfer.ui.icons.app.ArrowLeft
+import com.infomaniak.swisstransfer.ui.icons.app.Cross
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.PreviewMobile
 import com.infomaniak.swisstransfer.ui.utils.PreviewTablet
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
-fun SwissTransferTobAppBar() {
+fun SwissTransferTobAppBar(@StringRes titleRes: Int, navigationMenu: TopAppBarMenu? = null, vararg actionMenus: TopAppBarMenu) {
     TopAppBar(
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = SwissTransferTheme.materialColors.tertiary,
-            titleContentColor = Color.White, // TODO
+            titleContentColor = SwissTransferTheme.colors.toolbarTextColor,
+            actionIconContentColor = SwissTransferTheme.colors.toolbarIconColor,
+            navigationIconContentColor = SwissTransferTheme.colors.toolbarIconColor
         ),
-        title = {
-            Text("Title")
+        title = { Text(stringResource(id = titleRes)) },
+        navigationIcon = { navigationMenu?.let { MenuButton(navigationMenu) } },
+        actions = {
+            actionMenus.forEach { actionMenu -> MenuButton(actionMenu) }
         }
     )
+}
+
+@Composable
+private fun MenuButton(navigationMenu: TopAppBarMenu) {
+    IconButton(onClick = navigationMenu.onClick) {
+        Icon(imageVector = navigationMenu.icon, contentDescription = navigationMenu.contentDescription)
+    }
+}
+
+@Immutable
+data class TopAppBarMenu(
+    val icon: ImageVector,
+    val contentDescription: String?,
+    val onClick: () -> Unit,
+) {
+    companion object {
+        val backButton: (onClick: () -> Unit) -> TopAppBarMenu = { TopAppBarMenu(AppIcons.ArrowLeft, null, it) }
+        val closeButton: (onClick: () -> Unit) -> TopAppBarMenu = { TopAppBarMenu(AppIcons.Cross, null, it) }
+    }
 }
 
 @PreviewMobile
@@ -47,6 +75,11 @@ fun SwissTransferTobAppBar() {
 @Composable
 private fun SwissTransferTobAppBarPreview() {
     SwissTransferTheme {
-        SwissTransferTobAppBar()
+        SwissTransferTobAppBar(
+            R.string.appName,
+            TopAppBarMenu.backButton {},
+            TopAppBarMenu(AppIcons.Add, null, {}),
+            TopAppBarMenu.closeButton {}
+        )
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/icons/app/ArrowLeft.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/icons/app/ArrowLeft.kt
@@ -1,0 +1,63 @@
+package com.infomaniak.swisstransfer.ui.icons.app
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.infomaniak.swisstransfer.ui.icons.AppIcons
+
+val AppIcons.ArrowLeft: ImageVector
+    get() {
+        if (_arrowLeft != null) {
+            return _arrowLeft!!
+        }
+        _arrowLeft = Builder(
+            name = "ArrowLeft",
+            defaultWidth = 24.0.dp,
+            defaultHeight = 24.0.dp,
+            viewportWidth = 24.0f,
+            viewportHeight = 24.0f
+        ).apply {
+            path(
+                fill = null,
+                stroke = SolidColor(Color(0xFF9f9f9f)),
+                strokeLineWidth = 1.5f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(23.25f, 12.0f)
+                horizontalLineTo(0.75f)
+                moveToRelative(10.5f, -10.5f)
+                lineTo(0.75f, 12.0f)
+                lineToRelative(10.5f, 10.5f)
+            }
+        }.build()
+        return _arrowLeft!!
+    }
+
+private var _arrowLeft: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box {
+        Image(
+            imageVector = AppIcons.ArrowLeft,
+            contentDescription = null,
+            modifier = Modifier.size(AppIcons.previewSize)
+        )
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/icons/app/Cross.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/icons/app/Cross.kt
@@ -1,0 +1,62 @@
+package com.infomaniak.swisstransfer.ui.icons.app
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.group
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.infomaniak.swisstransfer.ui.icons.AppIcons
+import androidx.compose.ui.graphics.StrokeCap.Companion.Round as strokeCapRound
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Round as strokeJoinRound
+
+val AppIcons.Cross: ImageVector
+    get() {
+        if (_cross != null) {
+            return _cross!!
+        }
+        _cross = Builder(
+            name = "Cross", defaultWidth = 24.0.dp, defaultHeight = 24.0.dp, viewportWidth = 24.0f, viewportHeight = 24.0f
+        ).apply {
+            group {
+                path(
+                    fill = null,
+                    stroke = SolidColor(Color(0xFF9F9F9F)),
+                    strokeLineWidth = 1.5f,
+                    strokeLineCap = strokeCapRound,
+                    strokeLineJoin = strokeJoinRound,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero
+                ) {
+                    moveTo(0.75f, 23.249f)
+                    lineToRelative(22.5f, -22.5f)
+                    moveToRelative(0.0f, 22.5f)
+                    lineToRelative(-22.5f, -22.5f)
+                }
+            }
+        }.build()
+        return _cross!!
+    }
+
+private var _cross: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box {
+        Image(
+            imageVector = AppIcons.Cross,
+            contentDescription = null,
+            modifier = Modifier.size(AppIcons.previewSize)
+        )
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/icons/illu/LogoInfomaniak.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/icons/illu/LogoInfomaniak.kt
@@ -1,0 +1,275 @@
+package com.infomaniak.swisstransfer.ui.icons.illu
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.infomaniak.swisstransfer.ui.icons.AppIcons
+
+val AppIcons.Illu.LogoInfomaniak: ImageVector
+    get() {
+        if (_logoInfomaniak != null) {
+            return _logoInfomaniak!!
+        }
+        _logoInfomaniak = Builder(
+            name = "LogoInfomaniak",
+            defaultWidth = 128.0.dp,
+            defaultHeight = 16.0.dp,
+            viewportWidth = 128.0f,
+            viewportHeight = 16.0f
+        ).apply {
+            path(
+                fill = SolidColor(Color(0xFFFFFFFF)),
+                stroke = null,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(0.0f, 0.26f)
+                horizontalLineToRelative(4.34f)
+                verticalLineToRelative(2.92f)
+                lineTo(0.0f, 3.19f)
+                close()
+                moveToRelative(0.0f, 4.27f)
+                horizontalLineToRelative(4.34f)
+                verticalLineToRelative(11.22f)
+                horizontalLineTo(0.0f)
+                close()
+                moveToRelative(6.84f, 0.0f)
+                horizontalLineToRelative(4.05f)
+                verticalLineToRelative(1.83f)
+                quadToRelative(0.91f, -1.12f, 1.84f, -1.6f)
+                reflectiveQuadToRelative(2.26f, -0.48f)
+                quadToRelative(1.8f, 0.0f, 2.82f, 1.06f)
+                quadToRelative(1.02f, 1.06f, 1.02f, 3.28f)
+                verticalLineToRelative(7.13f)
+                horizontalLineToRelative(-4.37f)
+                verticalLineTo(9.58f)
+                quadToRelative(0.0f, -1.06f, -0.4f, -1.5f)
+                quadToRelative(-0.39f, -0.44f, -1.11f, -0.44f)
+                quadToRelative(-0.79f, 0.0f, -1.28f, 0.59f)
+                reflectiveQuadToRelative(-0.49f, 2.12f)
+                verticalLineToRelative(5.39f)
+                lineToRelative(-4.34f, 0.01f)
+                close()
+                moveToRelative(19.13f, 0.0f)
+                horizontalLineToRelative(2.07f)
+                verticalLineToRelative(3.15f)
+                horizontalLineToRelative(-2.07f)
+                verticalLineToRelative(8.07f)
+                horizontalLineToRelative(-4.36f)
+                verticalLineTo(7.68f)
+                horizontalLineToRelative(-1.62f)
+                verticalLineTo(4.53f)
+                horizontalLineToRelative(1.62f)
+                verticalLineTo(4.02f)
+                quadToRelative(0.0f, -0.69f, 0.15f, -1.51f)
+                quadToRelative(0.15f, -0.82f, 0.56f, -1.35f)
+                quadToRelative(0.41f, -0.52f, 1.15f, -0.85f)
+                quadTo(24.22f, 0.0f, 25.65f, 0.0f)
+                lineToRelative(0.38f, 0.01f)
+                quadToRelative(1.1f, 0.04f, 2.94f, 0.26f)
+                lineToRelative(-0.48f, 2.6f)
+                arcToRelative(8.0f, 8.0f, 0.0f, false, false, -1.26f, -0.13f)
+                quadToRelative(-0.59f, 0.0f, -0.84f, 0.2f)
+                quadToRelative(-0.26f, 0.19f, -0.36f, 0.62f)
+                quadToRelative(-0.05f, 0.23f, -0.05f, 0.98f)
+                moveToRelative(2.48f, 5.64f)
+                quadToRelative(0.0f, -2.57f, 1.75f, -4.23f)
+                quadToRelative(1.75f, -1.66f, 4.73f, -1.66f)
+                quadToRelative(3.4f, 0.0f, 5.14f, 1.95f)
+                quadToRelative(1.4f, 1.57f, 1.4f, 3.88f)
+                quadToRelative(0.0f, 2.59f, -1.74f, 4.24f)
+                reflectiveQuadTo(34.94f, 16.0f)
+                quadToRelative(-2.73f, 0.0f, -4.42f, -1.37f)
+                quadToRelative(-2.07f, -1.7f, -2.07f, -4.46f)
+                moveToRelative(4.36f, -0.01f)
+                quadToRelative(0.0f, 1.5f, 0.61f, 2.22f)
+                reflectiveQuadToRelative(1.54f, 0.72f)
+                quadToRelative(0.94f, 0.0f, 1.54f, -0.71f)
+                reflectiveQuadToRelative(0.6f, -2.27f)
+                quadToRelative(0.0f, -1.46f, -0.61f, -2.17f)
+                reflectiveQuadToRelative(-1.51f, -0.71f)
+                quadToRelative(-0.95f, 0.0f, -1.57f, 0.72f)
+                quadToRelative(-0.62f, 0.72f, -0.62f, 2.2f)
+                moveTo(43.3f, 4.53f)
+                horizontalLineToRelative(4.06f)
+                verticalLineToRelative(1.64f)
+                quadToRelative(0.88f, -1.02f, 1.77f, -1.46f)
+                quadToRelative(0.89f, -0.43f, 2.15f, -0.43f)
+                quadToRelative(1.36f, 0.0f, 2.15f, 0.47f)
+                quadToRelative(0.79f, 0.48f, 1.29f, 1.42f)
+                quadToRelative(1.02f, -1.1f, 1.87f, -1.5f)
+                quadToRelative(0.84f, -0.4f, 2.08f, -0.4f)
+                quadToRelative(1.83f, 0.0f, 2.85f, 1.07f)
+                reflectiveQuadToRelative(1.02f, 3.35f)
+                verticalLineToRelative(7.04f)
+                horizontalLineToRelative(-4.36f)
+                lineToRelative(0.01f, -6.37f)
+                quadToRelative(0.0f, -0.76f, -0.3f, -1.13f)
+                quadToRelative(-0.44f, -0.58f, -1.09f, -0.58f)
+                quadToRelative(-0.77f, 0.0f, -1.24f, 0.55f)
+                reflectiveQuadToRelative(-0.47f, 1.76f)
+                verticalLineToRelative(5.79f)
+                horizontalLineToRelative(-4.36f)
+                lineToRelative(0.01f, -6.18f)
+                quadToRelative(0.0f, -0.74f, -0.09f, -1.0f)
+                arcToRelative(1.37f, 1.37f, 0.0f, false, false, -0.48f, -0.68f)
+                arcToRelative(1.3f, 1.3f, 0.0f, false, false, -0.8f, -0.26f)
+                quadToRelative(-0.75f, 0.0f, -1.23f, 0.56f)
+                reflectiveQuadToRelative(-0.48f, 1.84f)
+                verticalLineToRelative(5.72f)
+                horizontalLineTo(43.3f)
+                close()
+                moveToRelative(25.51f, 3.63f)
+                lineToRelative(-4.15f, -0.43f)
+                quadToRelative(0.23f, -1.08f, 0.68f, -1.7f)
+                quadToRelative(0.44f, -0.62f, 1.27f, -1.07f)
+                quadToRelative(0.6f, -0.33f, 1.64f, -0.51f)
+                quadToRelative(1.05f, -0.18f, 2.26f, -0.18f)
+                quadToRelative(1.95f, 0.0f, 3.14f, 0.22f)
+                quadToRelative(1.18f, 0.22f, 1.98f, 0.9f)
+                quadToRelative(0.56f, 0.47f, 0.88f, 1.35f)
+                reflectiveQuadToRelative(0.32f, 1.66f)
+                verticalLineToRelative(4.95f)
+                quadToRelative(0.0f, 0.79f, 0.1f, 1.24f)
+                quadToRelative(0.1f, 0.45f, 0.44f, 1.15f)
+                horizontalLineToRelative(-4.08f)
+                arcToRelative(4.0f, 4.0f, 0.0f, false, true, -0.32f, -0.66f)
+                quadToRelative(-0.08f, -0.23f, -0.15f, -0.71f)
+                quadToRelative(-0.85f, 0.81f, -1.7f, 1.16f)
+                quadTo(69.97f, 16.0f, 68.44f, 16.0f)
+                quadToRelative(-2.03f, 0.0f, -3.08f, -0.93f)
+                quadToRelative(-1.05f, -0.93f, -1.05f, -2.29f)
+                quadToRelative(0.0f, -1.28f, 0.76f, -2.1f)
+                quadToRelative(0.7f, -0.76f, 2.51f, -1.16f)
+                lineToRelative(2.3f, -0.47f)
+                quadToRelative(0.79f, -0.17f, 1.15f, -0.27f)
+                quadToRelative(0.73f, -0.19f, 1.54f, -0.51f)
+                quadToRelative(0.0f, -0.79f, -0.33f, -1.11f)
+                quadToRelative(-0.33f, -0.32f, -1.16f, -0.32f)
+                quadToRelative(-1.07f, 0.0f, -1.6f, 0.34f)
+                quadToRelative(-0.42f, 0.26f, -0.67f, 0.99f)
+                moveToRelative(3.77f, 2.26f)
+                quadToRelative(-0.67f, 0.24f, -1.39f, 0.43f)
+                lineToRelative(-0.48f, 0.13f)
+                quadToRelative(-1.32f, 0.35f, -1.68f, 0.69f)
+                quadToRelative(-0.36f, 0.35f, -0.36f, 0.79f)
+                quadToRelative(0.0f, 0.51f, 0.36f, 0.83f)
+                quadToRelative(0.36f, 0.32f, 1.05f, 0.32f)
+                quadToRelative(0.73f, 0.0f, 1.35f, -0.35f)
+                quadToRelative(0.62f, -0.35f, 0.89f, -0.85f)
+                quadToRelative(0.26f, -0.5f, 0.26f, -1.3f)
+                close()
+                moveToRelative(6.57f, -5.9f)
+                horizontalLineToRelative(4.05f)
+                verticalLineToRelative(1.83f)
+                quadToRelative(0.91f, -1.12f, 1.84f, -1.6f)
+                reflectiveQuadToRelative(2.26f, -0.48f)
+                quadToRelative(1.8f, 0.0f, 2.82f, 1.06f)
+                quadToRelative(1.02f, 1.06f, 1.02f, 3.28f)
+                verticalLineToRelative(7.13f)
+                horizontalLineToRelative(-4.37f)
+                verticalLineTo(9.58f)
+                quadToRelative(0.0f, -1.06f, -0.4f, -1.5f)
+                quadToRelative(-0.39f, -0.44f, -1.11f, -0.44f)
+                quadToRelative(-0.79f, 0.0f, -1.28f, 0.59f)
+                reflectiveQuadToRelative(-0.49f, 2.12f)
+                verticalLineToRelative(5.39f)
+                horizontalLineToRelative(-4.34f)
+                close()
+                moveTo(93.6f, 0.26f)
+                horizontalLineToRelative(4.34f)
+                verticalLineToRelative(2.92f)
+                horizontalLineTo(93.6f)
+                close()
+                moveToRelative(0.0f, 4.27f)
+                horizontalLineToRelative(4.34f)
+                verticalLineToRelative(11.22f)
+                horizontalLineTo(93.6f)
+                close()
+                moveToRelative(10.8f, 3.63f)
+                lineToRelative(-4.16f, -0.43f)
+                quadToRelative(0.23f, -1.08f, 0.68f, -1.7f)
+                quadToRelative(0.44f, -0.62f, 1.28f, -1.07f)
+                quadToRelative(0.6f, -0.33f, 1.64f, -0.51f)
+                quadToRelative(1.05f, -0.18f, 2.26f, -0.18f)
+                quadToRelative(1.96f, 0.0f, 3.14f, 0.22f)
+                quadToRelative(1.18f, 0.22f, 1.98f, 0.9f)
+                quadToRelative(0.56f, 0.47f, 0.88f, 1.35f)
+                arcToRelative(4.8f, 4.8f, 0.0f, false, true, 0.32f, 1.66f)
+                verticalLineToRelative(4.95f)
+                quadToRelative(0.0f, 0.79f, 0.1f, 1.24f)
+                quadToRelative(0.1f, 0.45f, 0.44f, 1.15f)
+                horizontalLineToRelative(-4.08f)
+                lineToRelative(-0.14f, -0.26f)
+                arcToRelative(3.0f, 3.0f, 0.0f, false, true, -0.18f, -0.4f)
+                arcToRelative(5.0f, 5.0f, 0.0f, false, true, -0.15f, -0.71f)
+                quadToRelative(-0.85f, 0.81f, -1.7f, 1.16f)
+                quadToRelative(-1.15f, 0.47f, -2.68f, 0.47f)
+                quadToRelative(-2.03f, 0.0f, -3.08f, -0.93f)
+                quadToRelative(-1.05f, -0.93f, -1.05f, -2.29f)
+                quadToRelative(0.0f, -1.28f, 0.76f, -2.1f)
+                quadToRelative(0.7f, -0.76f, 2.51f, -1.16f)
+                lineToRelative(2.3f, -0.47f)
+                quadToRelative(0.79f, -0.17f, 1.15f, -0.27f)
+                quadToRelative(0.73f, -0.19f, 1.54f, -0.51f)
+                quadToRelative(0.0f, -0.79f, -0.33f, -1.11f)
+                quadToRelative(-0.33f, -0.32f, -1.16f, -0.32f)
+                quadToRelative(-1.07f, 0.0f, -1.6f, 0.34f)
+                quadToRelative(-0.42f, 0.26f, -0.67f, 0.99f)
+                moveToRelative(3.77f, 2.26f)
+                quadToRelative(-0.67f, 0.24f, -1.39f, 0.43f)
+                lineToRelative(-0.48f, 0.13f)
+                quadToRelative(-1.32f, 0.35f, -1.67f, 0.69f)
+                quadToRelative(-0.36f, 0.35f, -0.36f, 0.79f)
+                quadToRelative(0.0f, 0.51f, 0.36f, 0.83f)
+                quadToRelative(0.36f, 0.32f, 1.05f, 0.32f)
+                quadToRelative(0.73f, 0.0f, 1.35f, -0.35f)
+                quadToRelative(0.62f, -0.35f, 0.89f, -0.85f)
+                quadToRelative(0.26f, -0.5f, 0.26f, -1.3f)
+                close()
+                moveToRelative(6.56f, -10.17f)
+                horizontalLineToRelative(4.44f)
+                verticalLineToRelative(7.98f)
+                lineToRelative(3.24f, -3.72f)
+                horizontalLineToRelative(5.35f)
+                lineToRelative(-4.07f, 3.93f)
+                lineToRelative(4.31f, 7.3f)
+                horizontalLineToRelative(-4.9f)
+                lineToRelative(-2.3f, -4.5f)
+                lineToRelative(-1.63f, 1.59f)
+                verticalLineToRelative(2.91f)
+                horizontalLineToRelative(-4.44f)
+                close()
+            }
+        }.build()
+        return _logoInfomaniak!!
+    }
+
+private var _logoInfomaniak: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box {
+        Image(
+            imageVector = AppIcons.Illu.LogoInfomaniak,
+            contentDescription = null,
+            modifier = Modifier.size(AppIcons.previewSize)
+        )
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/icons/illu/LogoSwissTransfer.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/icons/illu/LogoSwissTransfer.kt
@@ -1,0 +1,156 @@
+package com.infomaniak.swisstransfer.ui.icons.illu
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.EvenOdd
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.infomaniak.swisstransfer.ui.icons.AppIcons
+
+val AppIcons.Illu.LogoSwissTransfer: ImageVector
+    get() {
+        if (_logoSwissTransfer != null) {
+            return _logoSwissTransfer!!
+        }
+        _logoSwissTransfer = Builder(
+            name = "LogoSwissTransfer",
+            defaultWidth = 24.0.dp,
+            defaultHeight = 24.0.dp,
+            viewportWidth = 24.0f,
+            viewportHeight = 24.0f
+        ).apply {
+            path(
+                fill = SolidColor(Color(0xFFFFFFFF)),
+                stroke = null,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(0.0f, 4.0f)
+                arcToRelative(4.0f, 4.0f, 0.0f, false, true, 4.0f, -4.0f)
+                horizontalLineToRelative(16.0f)
+                arcToRelative(4.0f, 4.0f, 0.0f, false, true, 4.0f, 4.0f)
+                verticalLineToRelative(16.0f)
+                arcToRelative(4.0f, 4.0f, 0.0f, false, true, -4.0f, 4.0f)
+                horizontalLineTo(4.0f)
+                arcToRelative(4.0f, 4.0f, 0.0f, false, true, -4.0f, -4.0f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFF5AC78A)),
+                stroke = null,
+                fillAlpha = 0.5f,
+                strokeAlpha = 0.5f,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = EvenOdd
+            ) {
+                moveTo(8.783f, 4.797f)
+                arcToRelative(0.803f, 0.803f, 0.0f, false, true, 1.04f, -0.761f)
+                lineTo(18.67f, 6.73f)
+                arcToRelative(0.8f, 0.8f, 0.0f, false, true, 0.568f, 0.76f)
+                verticalLineToRelative(8.686f)
+                arcToRelative(0.803f, 0.803f, 0.0f, false, true, -1.04f, 0.761f)
+                lineTo(9.35f, 14.243f)
+                arcToRelative(0.8f, 0.8f, 0.0f, false, true, -0.568f, -0.76f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFF4EC483)),
+                stroke = null,
+                fillAlpha = 0.8f,
+                strokeAlpha = 0.8f,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = EvenOdd
+            ) {
+                moveTo(6.772f, 6.31f)
+                arcToRelative(0.803f, 0.803f, 0.0f, false, true, 1.041f, -0.761f)
+                lineToRelative(8.847f, 2.695f)
+                arcToRelative(0.8f, 0.8f, 0.0f, false, true, 0.567f, 0.76f)
+                verticalLineToRelative(8.686f)
+                arcToRelative(0.803f, 0.803f, 0.0f, false, true, -1.04f, 0.761f)
+                lineTo(7.34f, 15.756f)
+                arcToRelative(0.8f, 0.8f, 0.0f, false, true, -0.568f, -0.76f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFF3BB471)),
+                stroke = null,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = EvenOdd
+            ) {
+                moveTo(4.762f, 7.823f)
+                arcToRelative(0.803f, 0.803f, 0.0f, false, true, 1.04f, -0.761f)
+                lineToRelative(8.847f, 2.695f)
+                arcToRelative(0.8f, 0.8f, 0.0f, false, true, 0.568f, 0.76f)
+                verticalLineToRelative(8.686f)
+                arcToRelative(0.803f, 0.803f, 0.0f, false, true, -1.04f, 0.761f)
+                lineTo(5.33f, 17.27f)
+                arcToRelative(0.8f, 0.8f, 0.0f, false, true, -0.568f, -0.76f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFFFFFFFF)),
+                stroke = null,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = EvenOdd
+            ) {
+                moveTo(11.131f, 10.806f)
+                arcToRelative(0.7f, 0.7f, 0.0f, false, true, 0.179f, 0.232f)
+                lineToRelative(1.584f, 5.625f)
+                curveToRelative(0.119f, 0.254f, 0.039f, 0.502f, -0.178f, 0.556f)
+                arcToRelative(0.4f, 0.4f, 0.0f, false, true, -0.215f, -0.01f)
+                lineToRelative(-1.438f, -0.431f)
+                lineToRelative(0.068f, -1.972f)
+                lineToRelative(-1.3f, 1.628f)
+                lineToRelative(-2.672f, -0.827f)
+                curveToRelative(-0.247f, -0.074f, -0.448f, -0.335f, -0.448f, -0.583f)
+                quadToRelative(0.0f, -0.106f, 0.047f, -0.185f)
+                lineToRelative(0.9f, -2.213f)
+                curveToRelative(0.11f, -0.19f, 0.379f, -0.2f, 0.6f, -0.024f)
+                curveToRelative(0.088f, 0.07f, 0.16f, 0.163f, 0.203f, 0.264f)
+                lineToRelative(0.491f, 0.828f)
+                lineToRelative(1.572f, -2.892f)
+                curveToRelative(0.118f, -0.182f, 0.39f, -0.18f, 0.607f, 0.004f)
+            }
+        }.build()
+        return _logoSwissTransfer!!
+    }
+
+private var _logoSwissTransfer: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box {
+        Image(
+            imageVector = AppIcons.Illu.LogoSwissTransfer,
+            contentDescription = null,
+            modifier = Modifier.size(AppIcons.previewSize)
+        )
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferNavHost.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferNavHost.kt
@@ -39,7 +39,7 @@ fun NewTransferNavHost(navController: NavHostController) {
             ImportFilesScreen(navigateToTransferTypeScreen = { navController.navigate(TransferTypeDestination) })
         }
         composable<TransferTypeDestination> {
-            TransferTypeScreen(navigateToTransfer = { /*TODO*/ })
+            TransferTypeScreen(navigateToTransfer = { /*TODO*/ }, popBack = { navController.navigateUp() })
         }
         composable<TransferOptionsDestination> {
             TransferOptionsScreen()

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -49,7 +49,7 @@ fun ImportFilesScreen(navigateToTransferTypeScreen: () -> Unit) {
             SwissTransferTobAppBar(
                 titleRes = R.string.importFilesScreenTitle,
                 navigationMenu = null,
-                TopAppBarMenu.closeButton { /*TODO*/ }
+                TopAppBarButton.closeButton { /*TODO*/ }
             )
         },
         topButton = { modifier ->

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -45,7 +45,13 @@ fun ImportFilesScreen(navigateToTransferTypeScreen: () -> Unit) {
     var showUploadSourceChoiceBottomSheet by rememberSaveable { mutableStateOf(false) }
 
     BottomStickyButtonScaffold(
-        topBar = { SwissTransferTobAppBar() },
+        topBar = {
+            SwissTransferTobAppBar(
+                titleRes = R.string.importFilesScreenTitle,
+                navigationMenu = null,
+                TopAppBarMenu.closeButton { /*TODO*/ }
+            )
+        },
         topButton = { modifier ->
             LargeButton(
                 modifier = modifier,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/TransferTypeScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/TransferTypeScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.components.SwissTransferTobAppBar
+import com.infomaniak.swisstransfer.ui.components.TopAppBarButton
 import com.infomaniak.swisstransfer.ui.icons.AppIcons
 import com.infomaniak.swisstransfer.ui.icons.illu.ChainTilted
 import com.infomaniak.swisstransfer.ui.icons.illu.EnvelopeTilted
@@ -44,8 +45,14 @@ import com.infomaniak.swisstransfer.ui.utils.PreviewMobile
 import com.infomaniak.swisstransfer.ui.utils.PreviewTablet
 
 @Composable
-fun TransferTypeScreen(navigateToTransfer: (TransferType) -> Unit) {
-    Scaffold(topBar = { SwissTransferTobAppBar() }) { contentPaddings ->
+fun TransferTypeScreen(navigateToTransfer: (TransferType) -> Unit, popBack: () -> Unit) {
+    Scaffold(topBar = {
+        SwissTransferTobAppBar(
+            titleRes = R.string.transferTypeScreenTitle,
+            navigationMenu = TopAppBarButton.backButton(popBack),
+            TopAppBarButton.closeButton { /*TODO*/ }
+        )
+    }) { contentPaddings ->
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -102,6 +109,6 @@ enum class TransferType(
 @Composable
 private fun TransferTypeScreenPreview() {
     SwissTransferTheme {
-        TransferTypeScreen {}
+        TransferTypeScreen({}) {}
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/ColorDark.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/ColorDark.kt
@@ -39,8 +39,10 @@ private const val specific4 = 0xFFEAC35D
 private const val specific5 = 0xFF49DEFD
 
 // Extra palette
-private const val error = 0xFFFC8878
 private const val elephant = 0xFF666666
+private const val white = 0xFFFFFFFF
+
+private const val error = 0xFFFC8878
 
 val DarkColorScheme = darkColorScheme(
     primary = Color(green_main),
@@ -67,6 +69,7 @@ val CustomDarkColorScheme = CustomColorScheme(
     primaryTextColor = Color(rabbit),
     secondaryTextColor = Color(shark),
     tertiaryTextColor = Color(elephant),
+    toolbarTextColor = Color(white),
     iconColor = Color(shark),
     navigationItemBackground = Color(dark2),
     tertiaryButtonBackground = Color(dark2),

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/ColorDark.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/ColorDark.kt
@@ -70,6 +70,7 @@ val CustomDarkColorScheme = CustomColorScheme(
     secondaryTextColor = Color(shark),
     tertiaryTextColor = Color(elephant),
     toolbarTextColor = Color(white),
+    toolbarIconColor = Color(green_contrast),
     iconColor = Color(shark),
     navigationItemBackground = Color(dark2),
     tertiaryButtonBackground = Color(dark2),

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/ColorLight.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/ColorLight.kt
@@ -70,6 +70,7 @@ val CustomLightColorScheme = CustomColorScheme(
     primaryTextColor = Color(orca),
     secondaryTextColor = Color(elephant),
     tertiaryTextColor = Color(shark),
+    toolbarTextColor = Color(white),
     iconColor = Color(elephant),
     navigationItemBackground = LightColorScheme.background,
     tertiaryButtonBackground = Color(rabbit),

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/ColorLight.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/ColorLight.kt
@@ -71,6 +71,7 @@ val CustomLightColorScheme = CustomColorScheme(
     secondaryTextColor = Color(elephant),
     tertiaryTextColor = Color(shark),
     toolbarTextColor = Color(white),
+    toolbarIconColor = Color(green_contrast),
     iconColor = Color(elephant),
     navigationItemBackground = LightColorScheme.background,
     tertiaryButtonBackground = Color(rabbit),

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/Theme.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/Theme.kt
@@ -65,6 +65,7 @@ data class CustomColorScheme(
     val secondaryTextColor: Color = Color.Unspecified,
     val tertiaryTextColor: Color = Color.Unspecified,
     val toolbarTextColor: Color = Color.Unspecified,
+    val toolbarIconColor: Color = Color.Unspecified,
     val iconColor: Color = Color.Unspecified,
     val navigationItemBackground: Color = Color.Unspecified,
     val tertiaryButtonBackground: Color = Color.Unspecified,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/Theme.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/Theme.kt
@@ -64,6 +64,7 @@ data class CustomColorScheme(
     val primaryTextColor: Color = Color.Unspecified,
     val secondaryTextColor: Color = Color.Unspecified,
     val tertiaryTextColor: Color = Color.Unspecified,
+    val toolbarTextColor: Color = Color.Unspecified,
     val iconColor: Color = Color.Unspecified,
     val navigationItemBackground: Color = Color.Unspecified,
     val tertiaryButtonBackground: Color = Color.Unspecified,

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -20,6 +20,7 @@
     <string name="buttonNext">Weiter zu</string>
     <string name="contentDescriptionCreateNewTransferButton">Neuer Transfer</string>
     <string name="firstTransferDescription">Mache deine erste Überweisung!</string>
+    <string name="importFilesScreenTitle">Zu übertragende Dateien</string>
     <string name="receivedTitle">Empfangen</string>
     <string name="sentEmptyTitle">Unsere Geschichte beginnt hier</string>
     <string name="sentTitle">Gesendet</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -18,6 +18,8 @@
 <resources>
     <string name="buttonAddFiles">Dateien hinzufügen</string>
     <string name="buttonNext">Weiter zu</string>
+    <string name="contentDescriptionButtonBack">Zurück</string>
+    <string name="contentDescriptionButtonClose">Schliessen</string>
     <string name="contentDescriptionCreateNewTransferButton">Neuer Transfer</string>
     <string name="firstTransferDescription">Mache deine erste Überweisung!</string>
     <string name="importFilesScreenTitle">Zu übertragende Dateien</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -42,6 +42,7 @@
     <string name="transferTypeLink">Link</string>
     <string name="transferTypeProximity">In der Nähe</string>
     <string name="transferTypeQrCode">QR-Code</string>
+    <string name="transferTypeScreenTitle">Übertragen</string>
     <string name="transferTypeTitle">Schicke deine Dateien per</string>
     <string name="transferUploadSourceChoiceCamera">Kamera</string>
     <string name="transferUploadSourceChoiceFiles">Dateien durchsuchen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -20,6 +20,7 @@
     <string name="buttonNext">Siguiente</string>
     <string name="contentDescriptionCreateNewTransferButton">Nueva transferencia</string>
     <string name="firstTransferDescription">Realice su primera transferencia</string>
+    <string name="importFilesScreenTitle">Archivos para transferir</string>
     <string name="receivedTitle">Recibido</string>
     <string name="sentEmptyTitle">Nuestra historia comienza aquí</string>
     <string name="sentTitle">Enviado a</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -18,6 +18,8 @@
 <resources>
     <string name="buttonAddFiles">Añadir archivos</string>
     <string name="buttonNext">Siguiente</string>
+    <string name="contentDescriptionButtonBack">Volver</string>
+    <string name="contentDescriptionButtonClose">Cerrar</string>
     <string name="contentDescriptionCreateNewTransferButton">Nueva transferencia</string>
     <string name="firstTransferDescription">Realice su primera transferencia</string>
     <string name="importFilesScreenTitle">Archivos para transferir</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -42,6 +42,7 @@
     <string name="transferTypeLink">Enlace</string>
     <string name="transferTypeProximity">Proximidad</string>
     <string name="transferTypeQrCode">Código QR</string>
+    <string name="transferTypeScreenTitle">Transferencia</string>
     <string name="transferTypeTitle">Envía tus archivos por</string>
     <string name="transferUploadSourceChoiceCamera">Cámara</string>
     <string name="transferUploadSourceChoiceFiles">Examinar archivos</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -42,6 +42,7 @@
     <string name="transferTypeLink">Lien</string>
     <string name="transferTypeProximity">A proximité</string>
     <string name="transferTypeQrCode">QR Code</string>
+    <string name="transferTypeScreenTitle">Transfert</string>
     <string name="transferTypeTitle">Envoie tes fichiers par</string>
     <string name="transferUploadSourceChoiceCamera">Appareil photo</string>
     <string name="transferUploadSourceChoiceFiles">Parcourir les fichiers</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -18,6 +18,8 @@
 <resources>
     <string name="buttonAddFiles">Ajouter des fichiers</string>
     <string name="buttonNext">Suivant</string>
+    <string name="contentDescriptionButtonBack">Retour</string>
+    <string name="contentDescriptionButtonClose">Fermer</string>
     <string name="contentDescriptionCreateNewTransferButton">Nouveau transfert</string>
     <string name="firstTransferDescription">Fais ton premier transfert !</string>
     <string name="importFilesScreenTitle">Fichiers à transférer</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -20,6 +20,7 @@
     <string name="buttonNext">Suivant</string>
     <string name="contentDescriptionCreateNewTransferButton">Nouveau transfert</string>
     <string name="firstTransferDescription">Fais ton premier transfert !</string>
+    <string name="importFilesScreenTitle">Fichiers à transférer</string>
     <string name="receivedTitle">Recu</string>
     <string name="sentEmptyTitle">Notre histoire commence ici</string>
     <string name="sentTitle">Envoyé</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -20,6 +20,7 @@
     <string name="buttonNext">Avanti</string>
     <string name="contentDescriptionCreateNewTransferButton">Nuovo trasferimento</string>
     <string name="firstTransferDescription">Effettuate il vostro primo trasferimento!</string>
+    <string name="importFilesScreenTitle">File da trasferire</string>
     <string name="receivedTitle">Ricevuto</string>
     <string name="sentEmptyTitle">La nostra storia inizia qui</string>
     <string name="sentTitle">Inviato a</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -18,6 +18,8 @@
 <resources>
     <string name="buttonAddFiles">Aggiunta di file</string>
     <string name="buttonNext">Avanti</string>
+    <string name="contentDescriptionButtonBack">Indietro</string>
+    <string name="contentDescriptionButtonClose">Chiudere</string>
     <string name="contentDescriptionCreateNewTransferButton">Nuovo trasferimento</string>
     <string name="firstTransferDescription">Effettuate il vostro primo trasferimento!</string>
     <string name="importFilesScreenTitle">File da trasferire</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -42,7 +42,7 @@
     <string name="transferTypeLink">Link</string>
     <string name="transferTypeProximity">Vicino</string>
     <string name="transferTypeQrCode">Codice QR</string>
-    <string name="transferTypeTitle">Inviate i vostri file tramite</string>
+    <string name="transferTypeScreenTitle">Trasferimento</string>
     <string name="transferUploadSourceChoiceCamera">Macchina fotografica</string>
     <string name="transferUploadSourceChoiceFiles">Sfogliare i file</string>
     <string name="transferUploadSourceChoiceGallery">Galleria di foto e video</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,8 @@
 
     <string name="buttonAddFiles">Add files</string>
     <string name="buttonNext">Next</string>
+    <string name="contentDescriptionButtonBack">Back</string>
+    <string name="contentDescriptionButtonClose">Close</string>
     <string name="contentDescriptionCreateNewTransferButton">New transfer</string>
     <string name="firstTransferDescription">Make your first transfer!</string>
     <string name="importFilesScreenTitle">Files to transfer</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="transferTypeLink">Link</string>
     <string name="transferTypeProximity">Proximity</string>
     <string name="transferTypeQrCode">QR Code</string>
+    <string name="transferTypeScreenTitle">Transfer</string>
     <string name="transferTypeTitle">Send your files by</string>
     <string name="transferUploadSourceChoiceCamera">Camera</string>
     <string name="transferUploadSourceChoiceFiles">Browse files</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="buttonNext">Next</string>
     <string name="contentDescriptionCreateNewTransferButton">New transfer</string>
     <string name="firstTransferDescription">Make your first transfer!</string>
+    <string name="importFilesScreenTitle">Files to transfer</string>
     <string name="receivedTitle">Received</string>
     <string name="sentEmptyTitle">Our story begins here</string>
     <string name="sentTitle">Sent</string>


### PR DESCRIPTION
Add two components, one that displays the brand and one for when there's an actual title and icons. This top app bar makes it easy to add new icons and easy to reuse the common close and back icons as actions while preventing from forgetting to use a contentDescription.