### PR TITLE
Fix top app bar

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferTobAppBar.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferTobAppBar.kt
@@ -46,7 +46,7 @@ fun SwissTransferTobAppBar(
             actionIconContentColor = SwissTransferTheme.colors.toolbarIconColor,
             navigationIconContentColor = SwissTransferTheme.colors.toolbarIconColor,
         ),
-        title = { Text(stringResource(id = titleRes)) },
+        title = { Text(stringResource(id = titleRes), style = SwissTransferTheme.typography.h2) },
         navigationIcon = { navigationMenu?.let { MenuButton(navigationMenu) } },
         actions = { actionMenus.forEach { actionMenu -> MenuButton(actionMenu) } },
     )

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/components/OptionScaffold.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/components/OptionScaffold.kt
@@ -44,12 +44,12 @@ fun OptionScaffold(
     navigateBack: (() -> Unit)? = null,
 ) {
     Scaffold(topBar = {
-        val canDisplayBackButton = if (LocalNavType.current == NavigationSuiteType.NavigationBar) {
+        val backNavigationMenu = if (LocalNavType.current == NavigationSuiteType.NavigationBar) {
             TopAppBarButton.backButton(navigateBack ?: {})
         } else {
             null
         }
-        SwissTransferTobAppBar(topAppBarTitleRes, navigationMenu = canDisplayBackButton)
+        SwissTransferTobAppBar(topAppBarTitleRes, navigationMenu = backNavigationMenu)
     }) { paddingsValue ->
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/components/OptionScaffold.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/components/OptionScaffold.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -31,6 +32,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.infomaniak.swisstransfer.ui.components.SwissTransferTobAppBar
 import com.infomaniak.swisstransfer.ui.components.TopAppBarButton
+import com.infomaniak.swisstransfer.ui.screen.main.LocalNavType
 
 @Composable
 fun OptionScaffold(
@@ -42,7 +44,11 @@ fun OptionScaffold(
     navigateBack: (() -> Unit)? = null,
 ) {
     Scaffold(topBar = {
-        val canDisplayBackButton = navigateBack?.let { TopAppBarButton.backButton(navigateBack) }
+        val canDisplayBackButton = if (LocalNavType.current == NavigationSuiteType.NavigationBar) {
+            TopAppBarButton.backButton(navigateBack ?: {})
+        } else {
+            null
+        }
         SwissTransferTobAppBar(topAppBarTitleRes, navigationMenu = canDisplayBackButton)
     }) { paddingsValue ->
         Column(


### PR DESCRIPTION
Fixes the text style of the SwissTransferTobAppBar and the disappearing back arrow when navigating back from the settings

Depends on #66 