### PR TITLE
Simplify contentPadding usage

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/components/BrandTopAppBarScaffold.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/components/BrandTopAppBarScaffold.kt
@@ -24,7 +24,7 @@ import com.infomaniak.swisstransfer.ui.components.BrandTopAppBar
 @Composable
 fun BrandTopAppBarScaffold(
     floatingActionButton: @Composable () -> Unit = {},
-    content: @Composable (PaddingValues) -> Unit,
+    content: @Composable () -> Unit,
 ) {
     SmallWindowTopAppBarScaffold(
         smallWindowTopAppBar = { BrandTopAppBar() },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/components/SmallWindowTopAppBarScaffold.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/components/SmallWindowTopAppBarScaffold.kt
@@ -17,9 +17,12 @@
  */
 package com.infomaniak.swisstransfer.ui.screen.main.components
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.infomaniak.swisstransfer.ui.theme.LocalWindowAdaptiveInfo
 import com.infomaniak.swisstransfer.ui.utils.isWindowSmall
@@ -28,7 +31,7 @@ import com.infomaniak.swisstransfer.ui.utils.isWindowSmall
 fun SmallWindowTopAppBarScaffold(
     smallWindowTopAppBar: @Composable () -> Unit = {},
     floatingActionButton: @Composable () -> Unit = {},
-    content: @Composable (PaddingValues) -> Unit,
+    content: @Composable () -> Unit,
 ) {
     val windowAdaptiveInfo = LocalWindowAdaptiveInfo.current
 
@@ -36,11 +39,9 @@ fun SmallWindowTopAppBarScaffold(
         topBar = { if (windowAdaptiveInfo.isWindowSmall()) smallWindowTopAppBar() },
         floatingActionButton = floatingActionButton,
     ) { contentPadding ->
-        val paddingValues = if (windowAdaptiveInfo.isWindowSmall()) {
-            contentPadding
-        } else {
-            PaddingValues(all = 0.dp)
+        val paddingValues = if (windowAdaptiveInfo.isWindowSmall()) contentPadding else PaddingValues(all = 0.dp)
+        Box(modifier = Modifier.padding(paddingValues)) {
+            content()
         }
-        content(paddingValues)
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/received/ReceivedScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/received/ReceivedScreen.kt
@@ -52,12 +52,11 @@ fun ReceivedScreen(
 private fun ReceivedScreen(areTransfersEmpty: () -> Boolean) {
     BrandTopAppBarScaffold(
         floatingActionButton = { ReceivedEmptyFab(areTransfersEmpty) },
-    ) { contentPadding ->
+    ) {
         EmptyState(
             icon = AppIllus.MascotSearching,
             title = R.string.noTransferReceivedTitle,
             description = R.string.noTransferReceivedDescription,
-            modifier = Modifier.padding(contentPadding),
         )
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentEmptyScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentEmptyScreen.kt
@@ -39,9 +39,9 @@ import com.infomaniak.swisstransfer.ui.utils.PreviewLargeWindow
 import com.infomaniak.swisstransfer.ui.utils.PreviewSmallWindow
 
 @Composable
-fun SentEmptyScreen(modifier: Modifier) {
+fun SentEmptyScreen() {
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
@@ -91,7 +91,7 @@ fun SentEmptyScreen(modifier: Modifier) {
 private fun SentEmptyScreenPreview() {
     SwissTransferTheme {
         Surface {
-            SentEmptyScreen(modifier = Modifier)
+            SentEmptyScreen()
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentListScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentListScreen.kt
@@ -22,18 +22,14 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.PreviewLargeWindow
 import com.infomaniak.swisstransfer.ui.utils.PreviewSmallWindow
 import java.util.UUID
 
 @Composable
-fun SentListScreen(
-    modifier: Modifier = Modifier,
-    transfers: List<Any>,
-) {
-    LazyColumn(modifier) {
+fun SentListScreen(transfers: List<Any>) {
+    LazyColumn {
         items(items = transfers, key = { UUID.randomUUID() }) {
             Text(text = "Sent screen")
         }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
@@ -17,12 +17,10 @@
  */
 package com.infomaniak.swisstransfer.ui.screen.main.sent
 
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Surface
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.infomaniak.swisstransfer.ui.components.NewTransferFab
@@ -54,12 +52,11 @@ private fun SentScreen(transfers: List<Any>?) {
                 NewTransferFab(newTransferFabType = NewTransferFabType.BOTTOM_BAR)
             }
         },
-    ) { contentPadding ->
-        val modifier = Modifier.padding(contentPadding)
+    ) {
         if (transfers.isEmpty()) {
-            SentEmptyScreen(modifier)
+            SentEmptyScreen()
         } else {
-            SentListScreen(modifier, transfers)
+            SentListScreen(transfers)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsScreen.kt
@@ -57,12 +57,11 @@ fun SettingsScreen(
 ) {
     val selectedSetting = getSelectedSetting()
 
-    BrandTopAppBarScaffold { paddingsValue ->
+    BrandTopAppBarScaffold {
         Column(
             modifier = Modifier
                 .verticalScroll(rememberScrollState())
-                .selectableGroup()
-                .padding(paddingsValue),
+                .selectableGroup(),
         ) {
             Text(
                 modifier = Modifier.padding(horizontal = Margin.Medium, vertical = Margin.Large),

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/components/OptionScaffold.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/components/OptionScaffold.kt
@@ -19,7 +19,6 @@ package com.infomaniak.swisstransfer.ui.screen.main.settings.components
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -48,12 +47,8 @@ fun OptionScaffold(
 ) {
     SmallWindowTopAppBarScaffold(
         smallWindowTopAppBar = { SwissTransferTopAppBar(topAppBarTitleRes, TopAppBarButton.backButton(navigateBack ?: {})) },
-    ) { paddingsValue ->
-        Column(
-            modifier = Modifier
-                .verticalScroll(rememberScrollState())
-                .padding(paddingsValue),
-        ) {
+    ) {
+        Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
             OptionTitle(titleRes = optionTitleRes)
 
             var selectedItem by rememberSaveable { mutableIntStateOf(selectedSettingOptionPosition) }


### PR DESCRIPTION
Avoid passing the content padding through too many files when we don't need to. The freedom to handle the contentPaddings manually everywhere down the line is not needed.

Depends on #78 