### PR TITLE
Turn FileUiItem from interface to data class to make future replacement easier

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/FileItem.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/FileItem.kt
@@ -35,14 +35,14 @@ import com.infomaniak.swisstransfer.ui.theme.Margin
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
 
-// TODO: Get the interface from the shared kmp code
-interface FileUiItem {
-    val uid: String
-    val fileName: String
-    val fileSizeInBytes: Long
-    val mimeType: String?
-    val uri: String
-}
+// TODO: Get the data class from the shared kmp code
+data class FileUiItem(
+    val uid: String,
+    val fileName: String,
+    val fileSizeInBytes: Long,
+    val mimeType: String?,
+    val uri: String,
+)
 
 @Composable
 fun FileItem(

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/FileItem.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/FileItem.kt
@@ -36,7 +36,7 @@ import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
 
 // TODO: Get the data class from the shared kmp code
-data class FileUiItem(
+data class FileUi(
     val uid: String,
     val fileName: String,
     val fileSizeInBytes: Long,
@@ -46,7 +46,7 @@ data class FileUiItem(
 
 @Composable
 fun FileItem(
-    file: FileUiItem,
+    file: FileUi,
     isRemoveButtonVisible: Boolean,
     isCheckboxVisible: Boolean,
     isChecked: () -> Boolean = { false },
@@ -131,7 +131,7 @@ private fun FileItemContent(
 
 @PreviewAllWindows
 @Composable
-private fun FileItemPreview(@PreviewParameter(FileUiListPreviewParameter::class) files: List<FileUiItem>) {
+private fun FileItemPreview(@PreviewParameter(FileUiListPreviewParameter::class) files: List<FileUi>) {
     SwissTransferTheme {
         Surface {
             Column(

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/FileItemList.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/FileItemList.kt
@@ -33,7 +33,7 @@ import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
 @Composable
 fun FileItemList(
     modifier: Modifier = Modifier,
-    files: List<FileUiItem>,
+    files: List<FileUi>,
     isRemoveButtonVisible: Boolean,
     isCheckboxVisible: Boolean,
     isUidChecked: (String) -> Boolean,
@@ -61,7 +61,7 @@ fun FileItemList(
 
 @PreviewAllWindows
 @Composable
-private fun FileItemListPreview(@PreviewParameter(FileUiListPreviewParameter::class) files: List<FileUiItem>) {
+private fun FileItemListPreview(@PreviewParameter(FileUiListPreviewParameter::class) files: List<FileUi>) {
     SwissTransferTheme {
         FileItemList(
             files = files,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/FilePreview.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/FilePreview.kt
@@ -42,7 +42,7 @@ import com.infomaniak.swisstransfer.ui.utils.hasPreview
 
 @Composable
 fun FilePreview(
-    file: FileUiItem,
+    file: FileUi,
     circleColor: Color,
     circleSize: Dp,
 ) {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SmallFileItem.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SmallFileItem.kt
@@ -37,7 +37,7 @@ import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 @Composable
 fun SmallFileItem(
     modifier: Modifier = Modifier,
-    file: FileUiItem,
+    file: FileUi,
     smallFileTileSize: SmallFileTileSize,
     onRemove: (() -> Unit)? = null,
 ) {
@@ -67,7 +67,7 @@ enum class SmallFileTileSize(val size: Dp, val shape: Shape) {
 @Preview(name = "Light")
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)
 @Composable
-private fun SmallFileItemPreview(@PreviewParameter(FileUiListPreviewParameter::class) files: List<FileUiItem>) {
+private fun SmallFileItemPreview(@PreviewParameter(FileUiListPreviewParameter::class) files: List<FileUi>) {
     SwissTransferTheme {
         Surface(color = SwissTransferTheme.materialColors.surfaceContainerHighest) {
             Column(Modifier.padding(16.dp)) {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/previewparameter/FileUiListPreviewParameterProvider.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/previewparameter/FileUiListPreviewParameterProvider.kt
@@ -18,26 +18,26 @@
 package com.infomaniak.swisstransfer.ui.previewparameter
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-import com.infomaniak.swisstransfer.ui.components.FileUiItem
+import com.infomaniak.swisstransfer.ui.components.FileUi
 
-class FileUiListPreviewParameter : PreviewParameterProvider<List<FileUiItem>> {
-    override val values: Sequence<List<FileUiItem>> = sequenceOf(
+class FileUiListPreviewParameter : PreviewParameterProvider<List<FileUi>> {
+    override val values: Sequence<List<FileUi>> = sequenceOf(
         listOf(
-            FileUiItem(
+            FileUi(
                 fileName = "How to not get fired.pdf",
                 uid = "How to not get fired.pdf",
                 fileSizeInBytes = 10302130,
                 mimeType = null,
                 uri = "",
             ),
-            FileUiItem(
+            FileUi(
                 fileName = "Opening images tutorial.png",
                 uid = "Opening images tutorial.png",
                 fileSizeInBytes = 456782,
                 mimeType = null,
                 uri = "https://picsum.photos/200/300",
             ),
-            FileUiItem(
+            FileUi(
                 fileName = "The 5 step guide to turning it off and on again.docx",
                 uid = "The 5 step guide to turning it off and on again.docx",
                 fileSizeInBytes = 89723143,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/previewparameter/FileUiListPreviewParameterProvider.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/previewparameter/FileUiListPreviewParameterProvider.kt
@@ -23,27 +23,27 @@ import com.infomaniak.swisstransfer.ui.components.FileUiItem
 class FileUiListPreviewParameter : PreviewParameterProvider<List<FileUiItem>> {
     override val values: Sequence<List<FileUiItem>> = sequenceOf(
         listOf(
-            object : FileUiItem { // Non-image file
-                override val fileName: String = "How to not get fired.pdf"
-                override val uid: String = fileName
-                override val fileSizeInBytes: Long = 10302130
-                override val mimeType: String? = null
-                override val uri: String = ""
-            },
-            object : FileUiItem { // Image file
-                override val fileName: String = "Opening images tutorial.png"
-                override val uid: String = fileName
-                override val fileSizeInBytes: Long = 456782
-                override val mimeType: String? = null
-                override val uri: String = "https://picsum.photos/200/300"
-            },
-            object : FileUiItem {
-                override val fileName: String = "The 5 step guide to turning it off and on again.docx"
-                override val uid: String = fileName
-                override val fileSizeInBytes: Long = 89723143
-                override val mimeType: String? = null
-                override val uri: String = ""
-            },
+            FileUiItem(
+                fileName = "How to not get fired.pdf",
+                uid = "How to not get fired.pdf",
+                fileSizeInBytes = 10302130,
+                mimeType = null,
+                uri = "",
+            ),
+            FileUiItem(
+                fileName = "Opening images tutorial.png",
+                uid = "Opening images tutorial.png",
+                fileSizeInBytes = 456782,
+                mimeType = null,
+                uri = "https://picsum.photos/200/300",
+            ),
+            FileUiItem(
+                fileName = "The 5 step guide to turning it off and on again.docx",
+                uid = "The 5 step guide to turning it off and on again.docx",
+                fileSizeInBytes = 89723143,
+                mimeType = null,
+                uri = "",
+            ),
         )
     )
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/received/ReceivedScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/received/ReceivedScreen.kt
@@ -29,7 +29,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.components.EmptyState
 import com.infomaniak.swisstransfer.ui.components.FileItemList
-import com.infomaniak.swisstransfer.ui.components.FileUiItem
+import com.infomaniak.swisstransfer.ui.components.FileUi
 import com.infomaniak.swisstransfer.ui.images.AppImages.AppIllus
 import com.infomaniak.swisstransfer.ui.images.illus.MascotSearching
 import com.infomaniak.swisstransfer.ui.screen.main.components.BrandTopAppBarScaffold
@@ -72,21 +72,21 @@ private fun ReceivedScreen(
             )
         } else {
             val files = listOf(
-                FileUiItem(
+                FileUi(
                     fileName = "The 5-Step Guide to Not Breaking Your Code.txt",
                     uid = "The 5-Step Guide to Not Breaking Your Code.txt",
                     fileSizeInBytes = 57689032,
                     mimeType = null,
                     uri = "",
                 ),
-                FileUiItem(
+                FileUi(
                     fileName = "Introduction to Turning It Off and On Again.pptx",
                     uid = "Introduction to Turning It Off and On Again.pptx",
                     fileSizeInBytes = 89723143,
                     mimeType = null,
                     uri = "",
                 ),
-                FileUiItem(
+                FileUi(
                     fileName = "Learning to Copy and Paste: A Complete Guide.docx",
                     uid = "Learning to Copy and Paste: A Complete Guide.docx",
                     fileSizeInBytes = 237866728,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/received/ReceivedScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/received/ReceivedScreen.kt
@@ -71,25 +71,29 @@ private fun ReceivedScreen(
                 description = R.string.noTransferReceivedDescription,
             )
         } else {
-            val files = listOf(object : FileUiItem {
-                override val fileName: String = "The 5-Step Guide to Not Breaking Your Code.txt"
-                override val uid: String = fileName
-                override val fileSizeInBytes: Long = 57689032
-                override val mimeType: String? = null
-                override val uri: String = ""
-            }, object : FileUiItem {
-                override val fileName: String = "Introduction to Turning It Off and On Again.pptx"
-                override val uid: String = fileName
-                override val fileSizeInBytes: Long = 89723143
-                override val mimeType: String? = null
-                override val uri: String = ""
-            }, object : FileUiItem {
-                override val fileName: String = "Learning to Copy and Paste: A Complete Guide.docx"
-                override val uid: String = fileName
-                override val fileSizeInBytes: Long = 237866728
-                override val mimeType: String? = null
-                override val uri: String = ""
-            })
+            val files = listOf(
+                FileUiItem(
+                    fileName = "The 5-Step Guide to Not Breaking Your Code.txt",
+                    uid = "The 5-Step Guide to Not Breaking Your Code.txt",
+                    fileSizeInBytes = 57689032,
+                    mimeType = null,
+                    uri = "",
+                ),
+                FileUiItem(
+                    fileName = "Introduction to Turning It Off and On Again.pptx",
+                    uid = "Introduction to Turning It Off and On Again.pptx",
+                    fileSizeInBytes = 89723143,
+                    mimeType = null,
+                    uri = "",
+                ),
+                FileUiItem(
+                    fileName = "Learning to Copy and Paste: A Complete Guide.docx",
+                    uid = "Learning to Copy and Paste: A Complete Guide.docx",
+                    fileSizeInBytes = 237866728,
+                    mimeType = null,
+                    uri = "",
+                ),
+            )
             FileItemList(
                 modifier = Modifier.padding(Margin.Medium),
                 files = files,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentListScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentListScreen.kt
@@ -29,25 +29,29 @@ import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
 
 @Composable
 fun SentListScreen(transfers: List<Any>) {
-    val transfers = listOf(object : FileUiItem {
-        override val fileName: String = "The 5-Step Guide to Not Breaking Your Code.txt"
-        override val uid: String = fileName
-        override val fileSizeInBytes: Long = 57689032
-        override val mimeType: String? = null
-        override val uri: String = ""
-    }, object : FileUiItem {
-        override val fileName: String = "Introduction to Turning It Off and On Again.pptx"
-        override val uid: String = fileName
-        override val fileSizeInBytes: Long = 89723143
-        override val mimeType: String? = null
-        override val uri: String = ""
-    }, object : FileUiItem {
-        override val fileName: String = "Learning to Copy and Paste: A Complete Guide.docx"
-        override val uid: String = fileName
-        override val fileSizeInBytes: Long = 237866728
-        override val mimeType: String? = null
-        override val uri: String = ""
-    })
+    val transfers = listOf(
+        FileUiItem(
+            fileName = "The 5-Step Guide to Not Breaking Your Code.txt",
+            uid = "The 5-Step Guide to Not Breaking Your Code.txt",
+            fileSizeInBytes = 57689032,
+            mimeType = null,
+            uri = "",
+        ),
+        FileUiItem(
+            fileName = "Introduction to Turning It Off and On Again.pptx",
+            uid = "Introduction to Turning It Off and On Again.pptx",
+            fileSizeInBytes = 89723143,
+            mimeType = null,
+            uri = "",
+        ),
+        FileUiItem(
+            fileName = "Learning to Copy and Paste: A Complete Guide.docx",
+            uid = "Learning to Copy and Paste: A Complete Guide.docx",
+            fileSizeInBytes = 237866728,
+            mimeType = null,
+            uri = "",
+        ),
+    )
     FileItemList(
         modifier = Modifier.padding(Margin.Medium),
         files = transfers,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentListScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentListScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.infomaniak.swisstransfer.ui.components.FileItemList
-import com.infomaniak.swisstransfer.ui.components.FileUiItem
+import com.infomaniak.swisstransfer.ui.components.FileUi
 import com.infomaniak.swisstransfer.ui.theme.Margin
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
@@ -30,21 +30,21 @@ import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
 @Composable
 fun SentListScreen(transfers: List<Any>) {
     val transfers = listOf(
-        FileUiItem(
+        FileUi(
             fileName = "The 5-Step Guide to Not Breaking Your Code.txt",
             uid = "The 5-Step Guide to Not Breaking Your Code.txt",
             fileSizeInBytes = 57689032,
             mimeType = null,
             uri = "",
         ),
-        FileUiItem(
+        FileUi(
             fileName = "Introduction to Turning It Off and On Again.pptx",
             uid = "Introduction to Turning It Off and On Again.pptx",
             fileSizeInBytes = 89723143,
             mimeType = null,
             uri = "",
         ),
-        FileUiItem(
+        FileUi(
             fileName = "Learning to Copy and Paste: A Complete Guide.docx",
             uid = "Learning to Copy and Paste: A Complete Guide.docx",
             fileSizeInBytes = 237866728,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferViewModel.kt
@@ -20,7 +20,7 @@ package com.infomaniak.swisstransfer.ui.screen.newtransfer
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.infomaniak.swisstransfer.ui.components.FileUiItem
+import com.infomaniak.swisstransfer.ui.components.FileUi
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -32,8 +32,8 @@ import javax.inject.Inject
 @HiltViewModel
 class NewTransferViewModel @Inject constructor(private val transferFilesManager: TransferFilesManager) : ViewModel() {
 
-    private val _files = MutableStateFlow<List<FileUiItem>>(emptyList())
-    val files: StateFlow<List<FileUiItem>> = _files
+    private val _files = MutableStateFlow<List<FileUi>>(emptyList())
+    val files: StateFlow<List<FileUi>> = _files
 
     private val _failedFileCount = MutableSharedFlow<Int>()
     val failedFileCount: SharedFlow<Int> = _failedFileCount

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferFilesManager.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferFilesManager.kt
@@ -22,7 +22,7 @@ import android.content.Context
 import android.database.Cursor
 import android.net.Uri
 import android.provider.OpenableColumns
-import com.infomaniak.swisstransfer.ui.components.FileUiItem
+import com.infomaniak.swisstransfer.ui.components.FileUi
 import com.infomaniak.swisstransfer.ui.utils.FileNameUtils
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -30,9 +30,9 @@ import javax.inject.Singleton
 
 @Singleton
 class TransferFilesManager @Inject constructor(@ApplicationContext private val appContext: Context) {
-    fun getFiles(uris: List<Uri>, alreadyUsedFileNames: Set<String>): MutableSet<FileUiItem> {
+    fun getFiles(uris: List<Uri>, alreadyUsedFileNames: Set<String>): MutableSet<FileUi> {
         val currentUsedFileNames = alreadyUsedFileNames.toMutableSet()
-        val files = mutableSetOf<FileUiItem>()
+        val files = mutableSetOf<FileUi>()
 
         uris.forEach { uri ->
             getFile(uri, currentUsedFileNames)?.let { file ->
@@ -44,13 +44,13 @@ class TransferFilesManager @Inject constructor(@ApplicationContext private val a
         return files
     }
 
-    private fun getFile(uri: Uri, alreadyUsedFileNames: Set<String>): FileUiItem? {
+    private fun getFile(uri: Uri, alreadyUsedFileNames: Set<String>): FileUi? {
         val contentResolver: ContentResolver = appContext.contentResolver
         val cursor: Cursor? = contentResolver.query(uri, null, null, null, null)
 
         return cursor?.getFileNameAndSize()?.let { (name, size) ->
             val uniqueName = FileNameUtils.postfixExistingFileNames(name, alreadyUsedFileNames)
-            FileUiItem(fileName = uniqueName, uid = uniqueName, fileSizeInBytes = size, mimeType = null, uri = uri.toString())
+            FileUi(fileName = uniqueName, uid = uniqueName, fileSizeInBytes = size, mimeType = null, uri = uri.toString())
         }
     }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferFilesManager.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferFilesManager.kt
@@ -50,13 +50,7 @@ class TransferFilesManager @Inject constructor(@ApplicationContext private val a
 
         return cursor?.getFileNameAndSize()?.let { (name, size) ->
             val uniqueName = FileNameUtils.postfixExistingFileNames(name, alreadyUsedFileNames)
-            object: FileUiItem {
-                override val fileName: String = uniqueName
-                override val uid: String = fileName
-                override val fileSizeInBytes: Long = size
-                override val mimeType: String? = null
-                override val uri: String = uri.toString()
-            }
+            FileUiItem(fileName = uniqueName, uid = uniqueName, fileSizeInBytes = size, mimeType = null, uri = uri.toString())
         }
     }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -51,7 +51,7 @@ fun ImportFilesScreen(
 
 @Composable
 private fun ImportFilesScreen(
-    files: () -> List<FileUiItem>,
+    files: () -> List<FileUi>,
     removeFileByUid: (uid: String) -> Unit,
     addFiles: (List<Uri>) -> Unit,
     closeActivity: () -> Unit,
@@ -111,7 +111,7 @@ private fun ImportFilesScreen(
 
 @PreviewAllWindows
 @Composable
-private fun ImportFilesScreenPreview(@PreviewParameter(FileUiListPreviewParameter::class) files: List<FileUiItem>) {
+private fun ImportFilesScreenPreview(@PreviewParameter(FileUiListPreviewParameter::class) files: List<FileUi>) {
     SwissTransferTheme {
         ImportFilesScreen({ files }, {}, {}, closeActivity = {})
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/components/ImportedFilesCard.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/components/ImportedFilesCard.kt
@@ -47,7 +47,7 @@ import kotlinx.parcelize.Parcelize
 @Composable
 fun ImportedFilesCard(
     modifier: Modifier = Modifier,
-    files: () -> List<FileUiItem>,
+    files: () -> List<FileUi>,
     humanReadableSize: () -> String,
     showUploadSourceChoiceBottomSheet: () -> Unit,
     removeFileByUid: (uid: String) -> Unit,
@@ -140,7 +140,7 @@ private data class TransferLazyRowKey(
 @Preview(name = "Light")
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)
 @Composable
-private fun ImportededFilesCardPreview(@PreviewParameter(FileUiListPreviewParameter::class) files: List<FileUiItem>) {
+private fun ImportedFilesCardPreview(@PreviewParameter(FileUiListPreviewParameter::class) files: List<FileUi>) {
     SwissTransferTheme {
         ImportedFilesCard(
             modifier = Modifier.padding(Margin.Medium),

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/utils/FileUiItemExt.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/utils/FileUiItemExt.kt
@@ -18,8 +18,8 @@
 package com.infomaniak.swisstransfer.ui.utils
 
 import com.infomaniak.library.filetypes.FileType
-import com.infomaniak.swisstransfer.ui.components.FileUiItem
+import com.infomaniak.swisstransfer.ui.components.FileUi
 
-val FileUiItem.fileType: FileType get() = mimeType?.let { FileType.guessFromMimeType(it) } ?: FileType.guessFromFileName(fileName)
+val FileUi.fileType: FileType get() = mimeType?.let { FileType.guessFromMimeType(it) } ?: FileType.guessFromFileName(fileName)
 
-val FileUiItem.hasPreview: Boolean get() = fileType == FileType.IMAGE
+val FileUi.hasPreview: Boolean get() = fileType == FileType.IMAGE


### PR DESCRIPTION
This only turns FileUiItem from an interface into a data class and renames it into FileUi

Depends on #88 