### PR TITLE
Fix wording for proximity share

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadSuccessQrScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadSuccessQrScreen.kt
@@ -69,10 +69,10 @@ fun UploadSuccessQrScreen(transferType: TransferType) {
 @Composable
 private fun Content(transferType: TransferType) {
 
-    val uploadSuccessTitle = if (transferType == TransferType.QR_CODE) {
-        R.string.uploadSuccessQrTitle
-    } else {
+    val uploadSuccessTitle = if (transferType == TransferType.LINK) {
         R.string.uploadSuccessLinkTitle
+    } else {
+        R.string.uploadSuccessQrTitle
     }
 
     Column(


### PR DESCRIPTION
When sharing a link by proximity it's more natural to use the QR code wording rather than the link wording