### PR TITLE
Fix lifecycle of imported files in new transfer

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportationFilesManager.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportationFilesManager.kt
@@ -35,9 +35,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import java.io.File
 import java.io.InputStream
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
 class ImportationFilesManager @Inject constructor(
     @ApplicationContext private val appContext: Context,
     private val importLocalStorage: ImportLocalStorage,


### PR DESCRIPTION
Files were kept from one startActivity to the other because the manager that help the files was a singleton instead of being reinstanciated every time the view model is reinstanciated