### PR TITLE
Fix transfert type button's spacing

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/components/TransferTypeButton.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/components/TransferTypeButton.kt
@@ -44,7 +44,6 @@ fun TransferTypeButton(
 
     Button(
         modifier = Modifier
-            .padding(Margin.Micro)
             .height(Dimens.LargeButtonHeight)
             .border(width = Dimens.BorderWidth, color = borderColor, shape = CustomShapes.SMALL),
         shape = CustomShapes.SMALL,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/components/TransferTypeButtons.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/components/TransferTypeButtons.kt
@@ -20,8 +20,8 @@ package com.infomaniak.swisstransfer.ui.screen.newtransfer.importfiles.component
 import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -41,9 +41,8 @@ import com.infomaniak.swisstransfer.ui.utils.PreviewLightAndDark
 @Composable
 fun TransferTypeButtons(transferType: GetSetCallbacks<TransferType>) {
     Row(
-        modifier = Modifier
-            .horizontalScroll(rememberScrollState())
-            .padding(horizontal = Margin.Mini),
+        modifier = Modifier.horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(Margin.Mini),
     ) {
         for (transferTypeEntry in TransferType.entries) {
             TransferTypeButton(


### PR DESCRIPTION
The spacing was defined at multiple levels in order to have a specific amount of spacing when summing them all. This spacing at the end was too big compared to what we will want to have by the end for the design and it was defined to deeply inside the component.

Now the component doesn't specify any form of paddings and lets its parent handle this matter altogether