### PR TITLE
Display upload error screen when worker fails

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
@@ -88,7 +88,7 @@ private fun HandleProgressState(
     LaunchedEffect(uiState()) {
         when (currentUiState) {
             is UploadProgressUiState.Success -> navigateToUploadSuccess(currentUiState.transferUrl)
-            is UploadProgressUiState.Cancelled -> navigateToUploadError()
+            is UploadProgressUiState.Error -> navigateToUploadError()
             else -> Unit
         }
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressViewModel.kt
@@ -42,7 +42,7 @@ class UploadProgressViewModel @Inject constructor(
     @OptIn(ExperimentalCoroutinesApi::class)
     val transferProgressUiState = _transferUuidFlow.flatMapLatest { transferUuid ->
         when (transferUuid) {
-            null -> flow { emit(UploadWorker.UploadProgressUiState.Cancelled()) }
+            null -> flow { emit(UploadWorker.UploadProgressUiState.Error()) }
             else -> uploadWorkerScheduler.trackUploadProgressFlow(transferUuid).flowOn(ioDispatcher)
         }
     }.stateIn(

--- a/app/src/main/java/com/infomaniak/swisstransfer/workers/UploadWorker.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/workers/UploadWorker.kt
@@ -122,9 +122,9 @@ class UploadWorker @AssistedInject constructor(
                 return@mapLatest when (workInfo.state) {
                     State.RUNNING -> UploadProgressUiState.Progress(workInfo.progress).also { lastUploadedSize = it.uploadedSize }
                     State.SUCCEEDED -> UploadProgressUiState.Success.create(workInfo.outputData, sharedApiUrlCreator)
-                    State.CANCELLED -> UploadProgressUiState.Cancelled(lastUploadedSize)
+                    State.FAILED, State.CANCELLED -> UploadProgressUiState.Error(lastUploadedSize)
                     else -> UploadProgressUiState.Default
-                } ?: UploadProgressUiState.Cancelled(lastUploadedSize)
+                } ?: UploadProgressUiState.Error(lastUploadedSize)
             }.filterNotNull()
         }
 
@@ -156,7 +156,7 @@ class UploadWorker @AssistedInject constructor(
         }
 
         @Immutable
-        data class Cancelled(override val uploadedSize: Long = 0) : UploadProgressUiState(uploadedSize)
+        data class Error(override val uploadedSize: Long = 0) : UploadProgressUiState(uploadedSize)
     }
 
     companion object {


### PR DESCRIPTION
When the worker returned a Failure, it previously displayed the default ui state but a worker failure should display the upload error as the upload has stopped for good