### PR TITLE
Stop tracking activities in Matomo

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/MainActivity.kt
@@ -28,7 +28,6 @@ import androidx.compose.runtime.getValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.infomaniak.multiplatform_swisstransfer.common.models.Theme
-import com.infomaniak.swisstransfer.ui.MatomoSwissTransfer.trackScreen
 import com.infomaniak.swisstransfer.ui.screen.main.MainScreen
 import com.infomaniak.swisstransfer.ui.screen.main.settings.SettingsViewModel
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
@@ -49,7 +48,6 @@ class MainActivity : ComponentActivity() {
                 MainScreen()
             }
         }
-        trackScreen()
     }
 }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/NewTransferActivity.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/NewTransferActivity.kt
@@ -21,7 +21,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import com.infomaniak.swisstransfer.ui.MatomoSwissTransfer.trackScreen
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.NewTransferScreen
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -37,6 +36,5 @@ class NewTransferActivity : ComponentActivity() {
                 NewTransferScreen(closeActivity = { finish() })
             }
         }
-        trackScreen()
     }
 }


### PR DESCRIPTION
The different screens should be tracked when they're navigated to but tracking the activities doesn't provide any meaningful info