### PR TITLE
feat: Add a generic button component

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/Buttons.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/Buttons.kt
@@ -103,7 +103,7 @@ private fun CoreButton(
     onClick: () -> Unit,
     imageVector: ImageVector?,
 ) {
-    GenericButton(
+    SwissTransferButton(
         modifier.height(buttonSize.height),
         style,
         enabled,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/Buttons.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/Buttons.kt
@@ -93,7 +93,7 @@ fun SmallButton(
 
 @Composable
 private fun CoreButton(
-    titleRes: Int,
+    @StringRes titleRes: Int,
     modifier: Modifier,
     buttonSize: ButtonSize,
     style: ButtonType,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/Buttons.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/Buttons.kt
@@ -51,7 +51,7 @@ fun LargeButton(
     onClick: () -> Unit,
     imageVector: ImageVector? = null,
 ) {
-    CoreTextButton(
+    CoreButton(
         titleRes,
         modifier,
         ButtonSize.LARGE,
@@ -78,7 +78,7 @@ fun SmallButton(
     onClick: () -> Unit,
     imageVector: ImageVector? = null,
 ) {
-    CoreTextButton(
+    CoreButton(
         titleRes,
         modifier,
         ButtonSize.SMALL,
@@ -92,7 +92,7 @@ fun SmallButton(
 }
 
 @Composable
-private fun CoreTextButton(
+private fun CoreButton(
     titleRes: Int,
     modifier: Modifier,
     buttonSize: ButtonSize,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/Buttons.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/Buttons.kt
@@ -56,7 +56,7 @@ fun LargeButton(
     onClick: () -> Unit,
     imageVector: ImageVector? = null,
 ) {
-    CoreButton(
+    CoreTextButton(
         titleRes,
         modifier,
         ButtonSize.LARGE,
@@ -83,7 +83,7 @@ fun SmallButton(
     onClick: () -> Unit,
     imageVector: ImageVector? = null,
 ) {
-    CoreButton(
+    CoreTextButton(
         titleRes,
         modifier,
         ButtonSize.SMALL,
@@ -97,8 +97,8 @@ fun SmallButton(
 }
 
 @Composable
-private fun CoreButton(
-    @StringRes titleRes: Int,
+private fun CoreTextButton(
+    titleRes: Int,
     modifier: Modifier,
     buttonSize: ButtonSize,
     style: ButtonType,
@@ -108,41 +108,63 @@ private fun CoreButton(
     onClick: () -> Unit,
     imageVector: ImageVector?,
 ) {
+    GenericButton(
+        modifier.height(buttonSize.height),
+        style,
+        enabled,
+        showIndeterminateProgress,
+        progress,
+        onClick,
+    ) {
+        ButtonTextContent(imageVector, titleRes)
+    }
+}
+
+@Composable
+fun GenericButton(
+    modifier: Modifier,
+    style: ButtonType = ButtonType.PRIMARY,
+    enabled: () -> Boolean = { true },
+    showIndeterminateProgress: () -> Boolean = { false },
+    progress: (() -> Float)? = null,
+    onClick: () -> Unit,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    content: @Composable () -> Unit,
+) {
     val isEnabled by remember(progress) { derivedStateOf { enabled() && !showIndeterminateProgress() && progress == null } }
     val buttonColors = style.buttonColors()
 
     Button(
-        modifier = modifier.height(buttonSize.height),
+        modifier = modifier,
         colors = buttonColors,
         shape = CustomShapes.MEDIUM,
         enabled = isEnabled,
+        contentPadding = contentPadding,
         onClick = onClick,
     ) {
         when {
             progress != null -> {
                 val (progressColor, progressModifier) = getProgressSpecs(buttonColors)
-                KeepButtonSize(imageVector, titleRes) {
+                KeepButtonSize(content) {
                     CircularProgressIndicator(modifier = progressModifier, color = progressColor, progress = progress)
                 }
             }
             showIndeterminateProgress() -> {
                 val (progressColor, progressModifier) = getProgressSpecs(buttonColors)
-                KeepButtonSize(imageVector, titleRes) {
+                KeepButtonSize(content) {
                     CircularProgressIndicator(modifier = progressModifier, color = progressColor)
                 }
             }
-            else -> {
-                ButtonTextContent(imageVector, titleRes)
-            }
+            else -> content()
         }
     }
 }
 
 @Composable
-fun KeepButtonSize(imageVector: ImageVector?, titleRes: Int, content: @Composable () -> Unit) {
+fun KeepButtonSize(targetSizeContent: @Composable () -> Unit, content: @Composable () -> Unit) {
     Box(contentAlignment = Alignment.Center) {
         Row(modifier = Modifier.alpha(0f)) {
-            ButtonTextContent(imageVector, titleRes)
+            targetSizeContent()
         }
         content()
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/Buttons.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/Buttons.kt
@@ -20,15 +20,11 @@ package com.infomaniak.swisstransfer.ui.components
 import android.content.res.Configuration
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -37,7 +33,6 @@ import androidx.compose.ui.unit.dp
 import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.images.AppImages.AppIcons
 import com.infomaniak.swisstransfer.ui.images.icons.Add
-import com.infomaniak.swisstransfer.ui.theme.CustomShapes
 import com.infomaniak.swisstransfer.ui.theme.Dimens
 import com.infomaniak.swisstransfer.ui.theme.Margin
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
@@ -121,98 +116,12 @@ private fun CoreTextButton(
 }
 
 @Composable
-fun GenericButton(
-    modifier: Modifier,
-    style: ButtonType = ButtonType.PRIMARY,
-    enabled: () -> Boolean = { true },
-    showIndeterminateProgress: () -> Boolean = { false },
-    progress: (() -> Float)? = null,
-    onClick: () -> Unit,
-    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
-    content: @Composable () -> Unit,
-) {
-    val isEnabled by remember(progress) { derivedStateOf { enabled() && !showIndeterminateProgress() && progress == null } }
-    val buttonColors = style.buttonColors()
-
-    Button(
-        modifier = modifier,
-        colors = buttonColors,
-        shape = CustomShapes.MEDIUM,
-        enabled = isEnabled,
-        contentPadding = contentPadding,
-        onClick = onClick,
-    ) {
-        when {
-            progress != null -> {
-                val (progressColor, progressModifier) = getProgressSpecs(buttonColors)
-                KeepButtonSize(content) {
-                    CircularProgressIndicator(modifier = progressModifier, color = progressColor, progress = progress)
-                }
-            }
-            showIndeterminateProgress() -> {
-                val (progressColor, progressModifier) = getProgressSpecs(buttonColors)
-                KeepButtonSize(content) {
-                    CircularProgressIndicator(modifier = progressModifier, color = progressColor)
-                }
-            }
-            else -> content()
-        }
-    }
-}
-
-@Composable
-fun KeepButtonSize(targetSizeContent: @Composable () -> Unit, content: @Composable () -> Unit) {
-    Box(contentAlignment = Alignment.Center) {
-        Row(modifier = Modifier.alpha(0f)) {
-            targetSizeContent()
-        }
-        content()
-    }
-}
-
-@Composable
 private fun ButtonTextContent(imageVector: ImageVector?, titleRes: Int) {
     imageVector?.let {
         Icon(modifier = Modifier.size(Dimens.SmallIconSize), imageVector = it, contentDescription = null)
         Spacer(Modifier.width(Margin.Mini))
     }
     Text(text = stringResource(id = titleRes), style = SwissTransferTheme.typography.bodyMedium)
-}
-
-@Composable
-private fun getProgressSpecs(buttonColors: ButtonColors): Pair<Color, Modifier> {
-    val progressColor = buttonColors.disabledContentColor
-    val progressModifier = Modifier
-        .fillMaxHeight(0.8f)
-        .aspectRatio(1f)
-    return Pair(progressColor, progressModifier)
-}
-
-enum class ButtonType(val buttonColors: @Composable () -> ButtonColors) {
-    PRIMARY({
-        ButtonDefaults.buttonColors(
-            containerColor = SwissTransferTheme.materialColors.primary,
-            contentColor = SwissTransferTheme.materialColors.onPrimary,
-        )
-    }),
-    SECONDARY({
-        ButtonDefaults.buttonColors(
-            containerColor = SwissTransferTheme.colors.tertiaryButtonBackground,
-            contentColor = SwissTransferTheme.materialColors.primary,
-        )
-    }),
-    TERTIARY({
-        ButtonDefaults.buttonColors(
-            containerColor = Color.Transparent,
-            contentColor = SwissTransferTheme.materialColors.primary,
-        )
-    }),
-    ERROR({
-        ButtonDefaults.buttonColors(
-            containerColor = SwissTransferTheme.materialColors.error,
-            contentColor = SwissTransferTheme.materialColors.onError,
-        )
-    }),
 }
 
 private enum class ButtonSize(val height: Dp) {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/GenericButton.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/GenericButton.kt
@@ -32,6 +32,15 @@ import com.infomaniak.swisstransfer.ui.theme.CustomShapes
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.PreviewLightAndDark
 
+
+/**
+ * Most basic and customizable button component.
+ *
+ * Only needed for exceptional edge cases where [LargeButton] or [SmallButton] are not enough and we need more control over the
+ * button component.
+ *
+ * Specifying a progress has the priority over specifying showIndeterminateProgress.
+ */
 @Composable
 fun GenericButton(
     modifier: Modifier = Modifier,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/GenericButton.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/GenericButton.kt
@@ -82,7 +82,7 @@ fun GenericButton(
 }
 
 @Composable
-fun KeepButtonSize(targetSizeContent: @Composable () -> Unit, content: @Composable () -> Unit) {
+private fun KeepButtonSize(targetSizeContent: @Composable () -> Unit, content: @Composable () -> Unit) {
     Box(contentAlignment = Alignment.Center) {
         Row(modifier = Modifier.alpha(0f)) {
             targetSizeContent()

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/GenericButton.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/GenericButton.kt
@@ -1,0 +1,149 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.swisstransfer.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.infomaniak.swisstransfer.ui.theme.CustomShapes
+import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
+import com.infomaniak.swisstransfer.ui.utils.PreviewLightAndDark
+
+@Composable
+fun GenericButton(
+    modifier: Modifier = Modifier,
+    style: ButtonType = ButtonType.PRIMARY,
+    enabled: () -> Boolean = { true },
+    showIndeterminateProgress: () -> Boolean = { false },
+    progress: (() -> Float)? = null,
+    onClick: () -> Unit,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    content: @Composable () -> Unit,
+) {
+    val isEnabled by remember(progress) { derivedStateOf { enabled() && !showIndeterminateProgress() && progress == null } }
+    val buttonColors = style.buttonColors()
+
+    Button(
+        modifier = modifier,
+        colors = buttonColors,
+        shape = CustomShapes.MEDIUM,
+        enabled = isEnabled,
+        contentPadding = contentPadding,
+        onClick = onClick,
+    ) {
+        when {
+            progress != null -> {
+                val (progressColor, progressModifier) = getProgressSpecs(buttonColors)
+                KeepButtonSize(content) {
+                    CircularProgressIndicator(modifier = progressModifier, color = progressColor, progress = progress)
+                }
+            }
+            showIndeterminateProgress() -> {
+                val (progressColor, progressModifier) = getProgressSpecs(buttonColors)
+                KeepButtonSize(content) {
+                    CircularProgressIndicator(modifier = progressModifier, color = progressColor)
+                }
+            }
+            else -> content()
+        }
+    }
+}
+@Composable
+fun KeepButtonSize(targetSizeContent: @Composable () -> Unit, content: @Composable () -> Unit) {
+    Box(contentAlignment = Alignment.Center) {
+        Row(modifier = Modifier.alpha(0f)) {
+            targetSizeContent()
+        }
+        content()
+    }
+}
+@Composable
+private fun getProgressSpecs(buttonColors: ButtonColors): Pair<Color, Modifier> {
+    val progressColor = buttonColors.disabledContentColor
+    val progressModifier = Modifier
+        .fillMaxHeight(0.8f)
+        .aspectRatio(1f)
+    return Pair(progressColor, progressModifier)
+}
+
+enum class ButtonType(val buttonColors: @Composable () -> ButtonColors) {
+    PRIMARY({
+        ButtonDefaults.buttonColors(
+            containerColor = SwissTransferTheme.materialColors.primary,
+            contentColor = SwissTransferTheme.materialColors.onPrimary,
+        )
+    }),
+    SECONDARY({
+        ButtonDefaults.buttonColors(
+            containerColor = SwissTransferTheme.colors.tertiaryButtonBackground,
+            contentColor = SwissTransferTheme.materialColors.primary,
+        )
+    }),
+    TERTIARY({
+        ButtonDefaults.buttonColors(
+            containerColor = Color.Transparent,
+            contentColor = SwissTransferTheme.materialColors.primary,
+        )
+    }),
+    ERROR({
+        ButtonDefaults.buttonColors(
+            containerColor = SwissTransferTheme.materialColors.error,
+            contentColor = SwissTransferTheme.materialColors.onError,
+        )
+    }),
+}
+
+
+@PreviewLightAndDark
+@Composable
+private fun Preview() {
+    SwissTransferTheme {
+        Surface {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                ButtonType.entries.forEach { buttonType ->
+                    Row {
+                        GenericButton(
+                            modifier = Modifier.height(40.dp),
+                            style = buttonType,
+                            onClick = {},
+                            content = { Text("Click me!") },
+                        )
+
+                        Spacer(modifier = Modifier.width(12.dp))
+
+                        GenericButton(
+                            modifier = Modifier.height(40.dp),
+                            style = buttonType,
+                            onClick = {},
+                            progress = { 0.8f },
+                            content = { Text("Click me!") },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/GenericButton.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/GenericButton.kt
@@ -80,6 +80,7 @@ fun GenericButton(
         }
     }
 }
+
 @Composable
 fun KeepButtonSize(targetSizeContent: @Composable () -> Unit, content: @Composable () -> Unit) {
     Box(contentAlignment = Alignment.Center) {
@@ -89,6 +90,7 @@ fun KeepButtonSize(targetSizeContent: @Composable () -> Unit, content: @Composab
         content()
     }
 }
+
 @Composable
 private fun getProgressSpecs(buttonColors: ButtonColors): Pair<Color, Modifier> {
     val progressColor = buttonColors.disabledContentColor

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferButton.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferButton.kt
@@ -42,7 +42,7 @@ import com.infomaniak.swisstransfer.ui.utils.PreviewLightAndDark
  * Specifying a progress has the priority over specifying showIndeterminateProgress.
  */
 @Composable
-fun GenericButton(
+fun SwissTransferButton(
     modifier: Modifier = Modifier,
     style: ButtonType = ButtonType.PRIMARY,
     enabled: () -> Boolean = { true },
@@ -136,7 +136,7 @@ private fun Preview() {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 ButtonType.entries.forEach { buttonType ->
                     Row {
-                        GenericButton(
+                        SwissTransferButton(
                             modifier = Modifier.height(40.dp),
                             style = buttonType,
                             onClick = {},
@@ -145,7 +145,7 @@ private fun Preview() {
 
                         Spacer(modifier = Modifier.width(12.dp))
 
-                        GenericButton(
+                        SwissTransferButton(
                             modifier = Modifier.height(40.dp),
                             style = buttonType,
                             onClick = {},


### PR DESCRIPTION
I need more control over the button to animate it properly in the onboarding screen of the app. This required me to extract a basic button that can be controlled more precisely than usually needed. 

This PR only abstracts this basic button in its own component and adapts the current buttons so they are defined on top of this basic button.

The only code that changed inside the definition of GenericButton compared to what was there previously can be seen in the first commit of the PR. It's the content of the button that became generic and the definition of the height of the button is not linked to ButtonSize at this level anymore