### PR TITLE
fix: Resume network with old uploaded size

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressViewModel.kt
@@ -48,7 +48,7 @@ class UploadProgressViewModel @Inject constructor(
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.Eagerly,
-        initialValue = UploadWorker.UploadProgressUiState.Default,
+        initialValue = UploadWorker.UploadProgressUiState.Default(),
     )
 
     fun trackUploadProgress() {


### PR DESCRIPTION
When the connection is lost, the worker goes into `enqueud` and receives the `Default` state, but the `Default` state does not contain the old `uploadedSize` data.