### PR TITLE
fix: HighlighterText's text when the argument is the last characters of the whole string

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/HighlightedText.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/HighlightedText.kt
@@ -187,7 +187,8 @@ private fun TextLayoutResult.getBoundingBoxesForRange(start: Int, end: Int): Lis
 
         // Check if we reached the end of the current bounding box (i.e. if we reached a new line or the last character in the range)
         if (previousRect != null && (areOnDifferentLines(previousRect, currentRect) || isLastCharacter)) {
-            boundingBoxes.add(firstBoundingBoxRect.copy(right = currentRect.right))
+            val lastBoundingBoxRect = if (isLastCharacter) currentRect else previousRect
+            boundingBoxes.add(firstBoundingBoxRect.copy(right = lastBoundingBoxRect.right))
 
             // Start a new line (reset firstBoundingBoxRect to the current character's rect)
             firstBoundingBoxRect = currentRect

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/HighlightedText.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/HighlightedText.kt
@@ -98,7 +98,7 @@ fun HighlightedText(
 
 private fun TextLayoutResult.getArgumentBoundingBoxes(text: String, argument: String): List<Rect> {
     val startIndex = text.indexOf(argument)
-    return getBoundingBoxesForRange(start = startIndex, end = startIndex + argument.count())
+    return getBoundingBoxesForRange(start = startIndex, end = startIndex + argument.count() - 1)
 }
 
 private fun List<Rect>.transformForHighlightedStyle(


### PR DESCRIPTION
Fix two issues when the argument of a HighlighterText are the last characters of the whole string. This PR also refactors the code to make it easier to understand because things were not named very clearly. The refactor and the fixes are visible in different commits.

---

Details of the bugs:

The range passed as argument to getBoundingBoxesForRange should stop at the last index of the string to not crash with an out of bound exception.

Also, the right coordinate of the each returned bounding box should be defined based on the current bounding box's last character's rect. This wasn't properly handled when the last character of the current bounding box was in any line but the last one of the whole string vs when it was at the end of the whole string