### PR TITLE
fix: Catch openInputStream crash and count it as a "failed file"

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportationFilesManager.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportationFilesManager.kt
@@ -118,7 +118,7 @@ class ImportationFilesManager @Inject constructor(
     }
 
     private fun openInputStream(uri: Uri): InputStream? {
-        return appContext.contentResolver.openInputStream(uri) ?: run {
+        return runCatching { appContext.contentResolver.openInputStream(uri) }.getOrNull() ?: run {
             SentryLog.w(ImportLocalStorage.TAG, "During local copy of the file openInputStream returned null")
             null
         }


### PR DESCRIPTION
openInputStream will crash and this needs to be caught and counted as a "failed file"