### PR TITLE
feat: Hide theme in settings if device is running on API below 29

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsScreen.kt
@@ -48,6 +48,7 @@ import com.infomaniak.swisstransfer.ui.theme.Margin
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.GetSetCallbacks
 import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
+import android.os.Build
 
 @Composable
 fun SettingsScreen(
@@ -73,14 +74,18 @@ fun SettingsScreen(
             )
 
             SettingTitle(R.string.settingsCategoryGeneral)
-            SettingItem(
-                titleRes = R.string.settingsOptionTheme,
-                isSelected = { selectedSetting == THEME },
-                icon = AppIcons.PaintbrushPalette,
-                description = theme.get().getString(),
-                endIcon = CHEVRON,
-                onClick = { onItemClick(THEME) },
-            )
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                SettingItem(
+                    titleRes = R.string.settingsOptionTheme,
+                    isSelected = { selectedSetting == THEME },
+                    icon = AppIcons.PaintbrushPalette,
+                    description = theme.get().getString(),
+                    endIcon = CHEVRON,
+                    onClick = { onItemClick(THEME) },
+                )
+            }
+
             SettingItem(
                 titleRes = R.string.settingsOptionNotifications,
                 isSelected = { false },


### PR DESCRIPTION
Dark theme is available since API 29: https://developer.android.com/develop/ui/views/theming/darktheme

- Left -> API 35
- Right -> API 28

<img width="1007" alt="Capture d’écran 2024-12-05 à 09 02 00" src="https://github.com/user-attachments/assets/030cdabd-bb45-4eeb-ab21-88180dbe9fd0">
