### PR TITLE
feat: Replace titleRes with actual string titles in buttons

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/BottomStickyButtonScaffold.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/BottomStickyButtonScaffold.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
-import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.theme.Dimens
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.PreviewLargeWindow
@@ -71,7 +70,7 @@ private fun Preview() {
         Surface {
             BottomStickyButtonScaffold(
                 topBar = { BrandTopAppBar() },
-                topButton = { modifier -> LargeButton(R.string.appName, onClick = {}, modifier = modifier) },
+                topButton = { modifier -> LargeButton("Top button", onClick = {}, modifier = modifier) },
             ) {
                 Text(
                     modifier = Modifier

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/Buttons.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/Buttons.kt
@@ -18,7 +18,6 @@
 package com.infomaniak.swisstransfer.ui.components
 
 import android.content.res.Configuration
-import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
@@ -26,11 +25,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.images.AppImages.AppIcons
 import com.infomaniak.swisstransfer.ui.images.icons.Add
 import com.infomaniak.swisstransfer.ui.theme.Dimens
@@ -42,7 +39,7 @@ import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
  */
 @Composable
 fun LargeButton(
-    @StringRes titleRes: Int,
+    title: String,
     modifier: Modifier = Modifier,
     style: ButtonType = ButtonType.PRIMARY,
     enabled: () -> Boolean = { true },
@@ -52,7 +49,7 @@ fun LargeButton(
     imageVector: ImageVector? = null,
 ) {
     CoreButton(
-        titleRes,
+        title,
         modifier,
         ButtonSize.LARGE,
         style,
@@ -69,7 +66,7 @@ fun LargeButton(
  */
 @Composable
 fun SmallButton(
-    @StringRes titleRes: Int,
+    title: String,
     modifier: Modifier = Modifier,
     style: ButtonType = ButtonType.PRIMARY,
     enabled: () -> Boolean = { true },
@@ -79,7 +76,7 @@ fun SmallButton(
     imageVector: ImageVector? = null,
 ) {
     CoreButton(
-        titleRes,
+        title,
         modifier,
         ButtonSize.SMALL,
         style,
@@ -93,7 +90,7 @@ fun SmallButton(
 
 @Composable
 private fun CoreButton(
-    @StringRes titleRes: Int,
+    title: String,
     modifier: Modifier,
     buttonSize: ButtonSize,
     style: ButtonType,
@@ -111,17 +108,17 @@ private fun CoreButton(
         progress,
         onClick,
     ) {
-        ButtonTextContent(imageVector, titleRes)
+        ButtonTextContent(imageVector, title)
     }
 }
 
 @Composable
-private fun ButtonTextContent(imageVector: ImageVector?, titleRes: Int) {
+private fun ButtonTextContent(imageVector: ImageVector?, title: String) {
     imageVector?.let {
         Icon(modifier = Modifier.size(Dimens.SmallIconSize), imageVector = it, contentDescription = null)
         Spacer(Modifier.width(Margin.Mini))
     }
-    Text(text = stringResource(id = titleRes), style = SwissTransferTheme.typography.bodyMedium)
+    Text(text = title, style = SwissTransferTheme.typography.bodyMedium)
 }
 
 private enum class ButtonSize(val height: Dp) {
@@ -138,10 +135,10 @@ private fun LargeButtonPreview() {
             Column {
                 ButtonType.entries.forEach {
                     Row {
-                        LargeButton(titleRes = R.string.appName, style = it, onClick = {}, imageVector = AppIcons.Add)
+                        LargeButton(title = "SwissTransfer", style = it, onClick = {}, imageVector = AppIcons.Add)
                         Spacer(Modifier.width(Margin.Mini))
                         LargeButton(
-                            titleRes = R.string.appName,
+                            title = "SwissTransfer",
                             style = it,
                             progress = { 0.3f },
                             onClick = {},
@@ -150,10 +147,10 @@ private fun LargeButtonPreview() {
 
                         Spacer(Modifier.width(Margin.Mini))
 
-                        SmallButton(titleRes = R.string.appName, style = it, imageVector = AppIcons.Add, onClick = {})
+                        SmallButton(title = "SwissTransfer", style = it, imageVector = AppIcons.Add, onClick = {})
                         Spacer(Modifier.width(Margin.Mini))
                         SmallButton(
-                            titleRes = R.string.appName,
+                            title = "SwissTransfer",
                             style = it,
                             progress = { 0.3f },
                             imageVector = AppIcons.Add,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/DoubleButtonCombo.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/DoubleButtonCombo.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.theme.Dimens
 import com.infomaniak.swisstransfer.ui.theme.Margin
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
@@ -114,14 +113,14 @@ private fun DoubleButtonComboPreview() {
                 topButton = {
                     LargeButton(
                         modifier = it,
-                        titleRes = R.string.appName,
+                        title = "Top button",
                         onClick = {},
                     )
                 },
                 bottomButton = {
                     LargeButton(
                         modifier = it,
-                        titleRes = R.string.appName,
+                        title = "Bottom button",
                         onClick = {},
                     )
                 },
@@ -131,7 +130,7 @@ private fun DoubleButtonComboPreview() {
                 bottomButton = {
                     LargeButton(
                         modifier = it,
-                        titleRes = R.string.appName,
+                        title = "Single button",
                         onClick = {},
                     )
                 },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferAlertDialog.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferAlertDialog.kt
@@ -107,12 +107,12 @@ private fun ActionButtons(onDismissRequest: () -> Unit, onConfirmation: () -> Un
     ) {
         SmallButton(
             style = ButtonType.TERTIARY,
-            titleRes = RCore2.string.buttonCancel,
+            title = stringResource(RCore2.string.buttonCancel),
             onClick = onDismissRequest,
         )
         Spacer(Modifier.width(Margin.Micro))
         SmallButton(
-            titleRes = R.string.buttonConfirm,
+            title = stringResource(R.string.buttonConfirm),
             onClick = onConfirmation,
             enabled = isEnabled
         )

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferBottomSheet.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferBottomSheet.kt
@@ -162,7 +162,7 @@ private fun BottomSheetDefaultsPreview() {
                 topButton = {
                     LargeButton(
                         modifier = it,
-                        titleRes = R.string.appName,
+                        title = "Top button",
                         style = ButtonType.ERROR,
                         onClick = {},
                     )
@@ -170,7 +170,7 @@ private fun BottomSheetDefaultsPreview() {
                 bottomButton = {
                     LargeButton(
                         modifier = it,
-                        titleRes = R.string.appName,
+                        title = "Bottom button",
                         style = ButtonType.TERTIARY,
                         onClick = {},
                     )

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransferExpiredBottomSheet.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransferExpiredBottomSheet.kt
@@ -62,7 +62,7 @@ fun TransferExpiredBottomSheet(
         bottomButton = {
             LargeButton(
                 modifier = it,
-                titleRes = R.string.transferExpiredButton,
+                title = stringResource(R.string.transferExpiredButton),
                 imageVector = AppIcons.Bin,
                 onClick = {
                     onDeleteTransferClicked()

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/components/PasswordBottomSheet.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/components/PasswordBottomSheet.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.components.ButtonType
 import com.infomaniak.swisstransfer.ui.components.LargeButton
@@ -55,7 +56,7 @@ fun PasswordBottomSheet(isVisible: () -> Boolean, transferPassword: () -> String
         topButton = {
             LargeButton(
                 modifier = it,
-                titleRes = R.string.sharePasswordButton,
+                title = stringResource(R.string.sharePasswordButton),
                 imageVector = AppIcons.DocumentOnDocument,
                 onClick = {
                     context.copyText(
@@ -69,7 +70,7 @@ fun PasswordBottomSheet(isVisible: () -> Boolean, transferPassword: () -> String
         bottomButton = {
             LargeButton(
                 modifier = it,
-                titleRes = R.string.contentDescriptionButtonClose,
+                title = stringResource(R.string.contentDescriptionButtonClose),
                 style = ButtonType.SECONDARY,
                 onClick = closeBottomSheet,
             )

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/components/QrCodeBottomSheet.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/components/QrCodeBottomSheet.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.components.LargeButton
 import com.infomaniak.swisstransfer.ui.components.QrCode
@@ -41,7 +42,7 @@ fun QrCodeBottomSheet(isVisible: () -> Boolean, transferUrl: String, closeBottom
         bottomButton = {
             LargeButton(
                 modifier = it,
-                titleRes = R.string.contentDescriptionButtonClose,
+                title = stringResource(R.string.contentDescriptionButtonClose),
                 onClick = closeBottomSheet,
             )
         },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -364,7 +364,7 @@ private fun SendButton(
 
     LargeButton(
         modifier = modifier,
-        titleRes = R.string.transferSendButton,
+        title = stringResource(R.string.transferSendButton),
         style = ButtonType.PRIMARY,
         enabled = { importedFiles().isNotEmpty() && !isImporting && isSenderEmailCorrect },
         progress = progress,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadErrorScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadErrorScreen.kt
@@ -19,6 +19,7 @@ package com.infomaniak.swisstransfer.ui.screen.newtransfer.upload
 
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.components.BottomStickyButtonScaffold
 import com.infomaniak.swisstransfer.ui.components.BrandTopAppBar
@@ -37,7 +38,7 @@ fun UploadErrorScreen(navigateToImportFiles: () -> Unit) {
         bottomButton = {
             LargeButton(
                 modifier = it,
-                titleRes = RCore2.string.buttonRetry,
+                title = stringResource(RCore2.string.buttonRetry),
                 onClick = navigateToImportFiles,
             )
         }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
@@ -109,7 +109,7 @@ private fun UploadProgressScreen(
     BottomStickyButtonScaffold(
         topBar = { BrandTopAppBar() },
         bottomButton = {
-            LargeButton(RCore2.string.buttonCancel, modifier = it, onClick = { showBottomSheet.set(true) })
+            LargeButton(stringResource(RCore2.string.buttonCancel), modifier = it, onClick = { showBottomSheet.set(true) })
         },
     ) {
         Column(
@@ -159,7 +159,7 @@ private fun CancelUploadBottomSheet(onCancel: () -> Unit, closeButtonSheet: () -
         imageVector = AppIllus.RedCrossPaperPlanes.image(),
         topButton = {
             LargeButton(
-                titleRes = R.string.uploadCancelConfirmBottomSheetCancel,
+                title = stringResource(R.string.uploadCancelConfirmBottomSheetCancel),
                 modifier = it,
                 style = ButtonType.ERROR,
                 onClick = onCancel,
@@ -167,7 +167,7 @@ private fun CancelUploadBottomSheet(onCancel: () -> Unit, closeButtonSheet: () -
         },
         bottomButton = {
             LargeButton(
-                titleRes = R.string.uploadCancelConfirmBottomSheetClose,
+                title = stringResource(R.string.uploadCancelConfirmBottomSheetClose),
                 modifier = it,
                 style = ButtonType.TERTIARY,
                 onClick = closeButtonSheet,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadSuccessEmailScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadSuccessEmailScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.components.*
@@ -46,7 +47,7 @@ fun UploadSuccessEmailScreen(
         bottomButton = {
             LargeButton(
                 modifier = it,
-                titleRes = R.string.buttonFinished,
+                title = stringResource(R.string.buttonFinished),
                 onClick = closeActivity,
             )
         },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadSuccessQrScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadSuccessQrScreen.kt
@@ -52,7 +52,7 @@ fun UploadSuccessQrScreen(transferType: TransferTypeUi, transferUrl: String, clo
             LargeButton(
                 modifier = it,
                 style = ButtonType.PRIMARY,
-                titleRes = R.string.buttonFinished,
+                title = stringResource(R.string.buttonFinished),
                 onClick = closeActivity,
             )
         },


### PR DESCRIPTION
I need to pass a whole string and not a string res in a futur PR so I changed the signature of the buttons to make them more reusable. This also matches the type of signatures that material exposes already