### PR TITLE
feat: Add confirmation when trying to leave the new transfer flow

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/Buttons.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/Buttons.kt
@@ -42,7 +42,7 @@ import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 fun LargeButton(
     title: String,
     modifier: Modifier = Modifier,
-    style: ButtonType = ButtonType.PRIMARY,
+    style: ButtonType = ButtonType.Primary,
     enabled: () -> Boolean = { true },
     showIndeterminateProgress: () -> Boolean = { false },
     progress: (() -> Float)? = null,
@@ -69,7 +69,7 @@ fun LargeButton(
 fun SmallButton(
     title: String,
     modifier: Modifier = Modifier,
-    style: ButtonType = ButtonType.PRIMARY,
+    style: ButtonType = ButtonType.Primary,
     enabled: () -> Boolean = { true },
     showIndeterminateProgress: () -> Boolean = { false },
     progress: (() -> Float)? = null,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/Buttons.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/Buttons.kt
@@ -108,7 +108,7 @@ private fun CoreButton(
         showIndeterminateProgress,
         progress,
         onClick,
-        contentPadding = buttonSize.contentPadding
+        contentPadding = buttonSize.contentPadding,
     ) {
         ButtonTextContent(imageVector, title)
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/Buttons.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/Buttons.kt
@@ -19,6 +19,7 @@ package com.infomaniak.swisstransfer.ui.components
 
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.*
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -107,6 +108,7 @@ private fun CoreButton(
         showIndeterminateProgress,
         progress,
         onClick,
+        contentPadding = buttonSize.contentPadding
     ) {
         ButtonTextContent(imageVector, title)
     }
@@ -121,9 +123,9 @@ private fun ButtonTextContent(imageVector: ImageVector?, title: String) {
     Text(text = title, style = SwissTransferTheme.typography.bodyMedium)
 }
 
-private enum class ButtonSize(val height: Dp) {
-    LARGE(Dimens.LargeButtonHeight),
-    SMALL(40.dp),
+private enum class ButtonSize(val height: Dp, val contentPadding: PaddingValues) {
+    LARGE(Dimens.LargeButtonHeight, ButtonDefaults.ContentPadding),
+    SMALL(40.dp, PaddingValues(horizontal = Margin.Medium)),
 }
 
 @Preview(name = "Light", widthDp = 800)

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferAlertDialog.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferAlertDialog.kt
@@ -35,7 +35,7 @@ object SwissTransferAlertDialogDefaults {
     @Composable
     fun ConfirmButton(isEnabled: () -> Boolean = { true }, onClick: () -> Unit) {
         SmallButton(
-            style = ButtonType.TERTIARY,
+            style = ButtonType.Tertiary,
             title = stringResource(R.string.buttonConfirm),
             enabled = isEnabled,
             onClick = onClick,
@@ -45,7 +45,7 @@ object SwissTransferAlertDialogDefaults {
     @Composable
     fun CancelButton(onClick: () -> Unit) {
         SmallButton(
-            style = ButtonType.TERTIARY,
+            style = ButtonType.Tertiary,
             title = stringResource(RCore2.string.buttonCancel),
             onClick = onClick,
         )
@@ -157,7 +157,7 @@ private fun WideButtonsPreview() {
             SwissTransferAlertDialog(
                 titleRes = R.string.settingsOptionPassword,
                 descriptionRes = R.string.settingsPasswordDescription,
-                positiveButton = { SmallButton("A very looong and wide button", onClick = {}, style = ButtonType.TERTIARY) },
+                positiveButton = { SmallButton("A very looong and wide button", onClick = {}, style = ButtonType.Tertiary) },
                 negativeButton = { SwissTransferAlertDialogDefaults.CancelButton { } },
                 onDismiss = {},
             )

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferAlertDialog.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferAlertDialog.kt
@@ -116,15 +116,17 @@ private fun TitleAndDescription(titleRes: Int, descriptionRes: Int) {
     )
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun ActionButtons(
     positiveButton: @Composable () -> Unit,
     negativeButton: @Composable () -> Unit,
 ) {
-    Row(
+    FlowRow(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(Margin.Micro, Alignment.End),
-        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Margin.Mini, Alignment.End),
+        verticalArrangement = Arrangement.spacedBy(Margin.Mini),
+        itemVerticalAlignment = Alignment.CenterVertically,
     ) {
         negativeButton()
         positiveButton()
@@ -140,6 +142,22 @@ private fun PreviewAlertDialog() {
                 titleRes = R.string.settingsOptionPassword,
                 descriptionRes = R.string.settingsPasswordDescription,
                 positiveButton = { SwissTransferAlertDialogDefaults.confirmButton { } },
+                negativeButton = { SwissTransferAlertDialogDefaults.cancelButton { } },
+                onDismiss = {},
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun WideButtonsPreview() {
+    SwissTransferTheme {
+        Surface {
+            SwissTransferAlertDialog(
+                titleRes = R.string.settingsOptionPassword,
+                descriptionRes = R.string.settingsPasswordDescription,
+                positiveButton = { SmallButton("A very looong and wide button", onClick = {}) },
                 negativeButton = { SwissTransferAlertDialogDefaults.cancelButton { } },
                 onDismiss = {},
             )

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferAlertDialog.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferAlertDialog.kt
@@ -31,15 +31,35 @@ import com.infomaniak.swisstransfer.ui.theme.Margin
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.core2.R as RCore2
 
+object SwissTransferAlertDialogDefaults {
+    @Composable
+    fun confirmButton(isEnabled: () -> Boolean = { true }, onClick: () -> Unit) {
+        SmallButton(
+            title = stringResource(R.string.buttonConfirm),
+            enabled = isEnabled,
+            onClick = onClick,
+        )
+    }
+
+    @Composable
+    fun cancelButton(onClick: () -> Unit) {
+        SmallButton(
+            style = ButtonType.TERTIARY,
+            title = stringResource(RCore2.string.buttonCancel),
+            onClick = onClick,
+        )
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SwissTransferAlertDialog(
     modifier: Modifier = Modifier,
     @StringRes titleRes: Int,
     @StringRes descriptionRes: Int,
+    positiveButton: @Composable () -> Unit,
+    negativeButton: @Composable () -> Unit,
     onDismiss: () -> Unit,
-    onConfirmation: () -> Unit,
-    isConfirmButtonEnabled: () -> Boolean = { true },
     content: @Composable (ColumnScope.() -> Unit)? = null,
 ) {
     BasicAlertDialog(
@@ -52,11 +72,10 @@ fun SwissTransferAlertDialog(
             BasicAlertDialogContent(
                 modifier = modifier,
                 titleRes = titleRes,
+                positiveButton = positiveButton,
+                negativeButton = negativeButton,
                 descriptionRes = descriptionRes,
                 additionalContent = content,
-                onDismiss = onDismiss,
-                onConfirmation = onConfirmation,
-                isConfirmButtonEnabled = isConfirmButtonEnabled,
             )
         }
     }
@@ -67,10 +86,9 @@ private fun BasicAlertDialogContent(
     modifier: Modifier,
     @StringRes titleRes: Int,
     @StringRes descriptionRes: Int,
+    positiveButton: @Composable () -> Unit,
+    negativeButton: @Composable () -> Unit,
     additionalContent: @Composable (ColumnScope.() -> Unit)? = null,
-    onDismiss: () -> Unit,
-    onConfirmation: () -> Unit,
-    isConfirmButtonEnabled: () -> Boolean = { true },
 ) {
     Column(modifier.padding(Margin.Large)) {
         TitleAndDescription(titleRes, descriptionRes)
@@ -79,7 +97,7 @@ private fun BasicAlertDialogContent(
             it()
             Spacer(Modifier.height(Margin.Mini))
         }
-        ActionButtons(onDismiss, onConfirmation, isConfirmButtonEnabled)
+        ActionButtons(positiveButton, negativeButton)
     }
 }
 
@@ -99,23 +117,17 @@ private fun TitleAndDescription(titleRes: Int, descriptionRes: Int) {
 }
 
 @Composable
-private fun ActionButtons(onDismissRequest: () -> Unit, onConfirmation: () -> Unit, isEnabled: () -> Boolean) {
+private fun ActionButtons(
+    positiveButton: @Composable () -> Unit,
+    negativeButton: @Composable () -> Unit,
+) {
     Row(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.End,
+        horizontalArrangement = Arrangement.spacedBy(Margin.Micro, Alignment.End),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        SmallButton(
-            style = ButtonType.TERTIARY,
-            title = stringResource(RCore2.string.buttonCancel),
-            onClick = onDismissRequest,
-        )
-        Spacer(Modifier.width(Margin.Micro))
-        SmallButton(
-            title = stringResource(R.string.buttonConfirm),
-            onClick = onConfirmation,
-            enabled = isEnabled
-        )
+        negativeButton()
+        positiveButton()
     }
 }
 
@@ -127,8 +139,9 @@ private fun PreviewAlertDialog() {
             SwissTransferAlertDialog(
                 titleRes = R.string.settingsOptionPassword,
                 descriptionRes = R.string.settingsPasswordDescription,
+                positiveButton = { SwissTransferAlertDialogDefaults.confirmButton { } },
+                negativeButton = { SwissTransferAlertDialogDefaults.cancelButton { } },
                 onDismiss = {},
-                onConfirmation = {},
             )
         }
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferAlertDialog.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferAlertDialog.kt
@@ -33,7 +33,7 @@ import com.infomaniak.core2.R as RCore2
 
 object SwissTransferAlertDialogDefaults {
     @Composable
-    fun confirmButton(isEnabled: () -> Boolean = { true }, onClick: () -> Unit) {
+    fun ConfirmButton(isEnabled: () -> Boolean = { true }, onClick: () -> Unit) {
         SmallButton(
             style = ButtonType.TERTIARY,
             title = stringResource(R.string.buttonConfirm),
@@ -43,7 +43,7 @@ object SwissTransferAlertDialogDefaults {
     }
 
     @Composable
-    fun cancelButton(onClick: () -> Unit) {
+    fun CancelButton(onClick: () -> Unit) {
         SmallButton(
             style = ButtonType.TERTIARY,
             title = stringResource(RCore2.string.buttonCancel),
@@ -141,8 +141,8 @@ private fun PreviewAlertDialog() {
             SwissTransferAlertDialog(
                 titleRes = R.string.settingsOptionPassword,
                 descriptionRes = R.string.settingsPasswordDescription,
-                positiveButton = { SwissTransferAlertDialogDefaults.confirmButton { } },
-                negativeButton = { SwissTransferAlertDialogDefaults.cancelButton { } },
+                positiveButton = { SwissTransferAlertDialogDefaults.ConfirmButton { } },
+                negativeButton = { SwissTransferAlertDialogDefaults.CancelButton { } },
                 onDismiss = {},
             )
         }
@@ -158,7 +158,7 @@ private fun WideButtonsPreview() {
                 titleRes = R.string.settingsOptionPassword,
                 descriptionRes = R.string.settingsPasswordDescription,
                 positiveButton = { SmallButton("A very looong and wide button", onClick = {}, style = ButtonType.TERTIARY) },
-                negativeButton = { SwissTransferAlertDialogDefaults.cancelButton { } },
+                negativeButton = { SwissTransferAlertDialogDefaults.CancelButton { } },
                 onDismiss = {},
             )
         }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferAlertDialog.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferAlertDialog.kt
@@ -35,6 +35,7 @@ object SwissTransferAlertDialogDefaults {
     @Composable
     fun confirmButton(isEnabled: () -> Boolean = { true }, onClick: () -> Unit) {
         SmallButton(
+            style = ButtonType.TERTIARY,
             title = stringResource(R.string.buttonConfirm),
             enabled = isEnabled,
             onClick = onClick,
@@ -124,8 +125,7 @@ private fun ActionButtons(
 ) {
     FlowRow(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(Margin.Mini, Alignment.End),
-        verticalArrangement = Arrangement.spacedBy(Margin.Mini),
+        horizontalArrangement = Arrangement.End,
         itemVerticalAlignment = Alignment.CenterVertically,
     ) {
         negativeButton()
@@ -157,7 +157,7 @@ private fun WideButtonsPreview() {
             SwissTransferAlertDialog(
                 titleRes = R.string.settingsOptionPassword,
                 descriptionRes = R.string.settingsPasswordDescription,
-                positiveButton = { SmallButton("A very looong and wide button", onClick = {}) },
+                positiveButton = { SmallButton("A very looong and wide button", onClick = {}, style = ButtonType.TERTIARY) },
                 negativeButton = { SwissTransferAlertDialogDefaults.cancelButton { } },
                 onDismiss = {},
             )

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferBottomSheet.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferBottomSheet.kt
@@ -161,7 +161,7 @@ private fun BottomSheetDefaultsPreview() {
                     LargeButton(
                         modifier = it,
                         title = "Top button",
-                        style = ButtonType.ERROR,
+                        style = ButtonType.DESTRUCTIVE,
                         onClick = {},
                     )
                 },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferBottomSheet.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferBottomSheet.kt
@@ -161,7 +161,7 @@ private fun BottomSheetDefaultsPreview() {
                     LargeButton(
                         modifier = it,
                         title = "Top button",
-                        style = ButtonType.DESTRUCTIVE,
+                        style = ButtonType.Destructive,
                         onClick = {},
                     )
                 },
@@ -169,7 +169,7 @@ private fun BottomSheetDefaultsPreview() {
                     LargeButton(
                         modifier = it,
                         title = "Bottom button",
-                        style = ButtonType.TERTIARY,
+                        style = ButtonType.Tertiary,
                         onClick = {},
                     )
                 },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferButton.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferButton.kt
@@ -43,7 +43,7 @@ import com.infomaniak.swisstransfer.ui.utils.PreviewLightAndDark
 @Composable
 fun SwissTransferButton(
     modifier: Modifier = Modifier,
-    style: ButtonType = ButtonType.PRIMARY,
+    style: ButtonType = ButtonType.Primary,
     enabled: () -> Boolean = { true },
     showIndeterminateProgress: () -> Boolean = { false },
     progress: (() -> Float)? = null,
@@ -100,31 +100,31 @@ private fun getProgressSpecs(buttonColors: ButtonColors): Pair<Color, Modifier> 
 }
 
 enum class ButtonType(val buttonColors: @Composable () -> ButtonColors) {
-    PRIMARY({
+    Primary({
         ButtonDefaults.buttonColors(
             containerColor = SwissTransferTheme.materialColors.primary,
             contentColor = SwissTransferTheme.materialColors.onPrimary,
         )
     }),
-    SECONDARY({
+    Secondary({
         ButtonDefaults.buttonColors(
             containerColor = SwissTransferTheme.colors.tertiaryButtonBackground,
             contentColor = SwissTransferTheme.materialColors.primary,
         )
     }),
-    TERTIARY({
+    Tertiary({
         ButtonDefaults.buttonColors(
             containerColor = Color.Transparent,
             contentColor = SwissTransferTheme.materialColors.primary,
         )
     }),
-    DESTRUCTIVE({
+    Destructive({
         ButtonDefaults.buttonColors(
             containerColor = SwissTransferTheme.materialColors.error,
             contentColor = SwissTransferTheme.materialColors.onError,
         )
     }),
-    DESTRUCTIVE_TEXT({
+    DestructiveText({
         ButtonDefaults.buttonColors(
             containerColor = Color.Transparent,
             contentColor = SwissTransferTheme.materialColors.error,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferButton.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferButton.kt
@@ -124,6 +124,12 @@ enum class ButtonType(val buttonColors: @Composable () -> ButtonColors) {
             contentColor = SwissTransferTheme.materialColors.onError,
         )
     }),
+    ERROR_TEXT({
+        ButtonDefaults.buttonColors(
+            containerColor = Color.Transparent,
+            contentColor = SwissTransferTheme.materialColors.error,
+        )
+    }),
 }
 
 @PreviewLightAndDark

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferButton.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferButton.kt
@@ -118,13 +118,13 @@ enum class ButtonType(val buttonColors: @Composable () -> ButtonColors) {
             contentColor = SwissTransferTheme.materialColors.primary,
         )
     }),
-    ERROR({
+    DESTRUCTIVE({
         ButtonDefaults.buttonColors(
             containerColor = SwissTransferTheme.materialColors.error,
             contentColor = SwissTransferTheme.materialColors.onError,
         )
     }),
-    ERROR_TEXT({
+    DESTRUCTIVE_TEXT({
         ButtonDefaults.buttonColors(
             containerColor = Color.Transparent,
             contentColor = SwissTransferTheme.materialColors.error,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/TransferDetailsScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/TransferDetailsScreen.kt
@@ -280,7 +280,7 @@ private fun RowScope.BottomBarButton(
     onClick: () -> Unit,
 ) = Button(
     modifier = Modifier.weight(1.0f),
-    colors = ButtonType.TERTIARY.buttonColors(),
+    colors = ButtonType.Tertiary.buttonColors(),
     enabled = enabled,
     onClick = { onClick() },
 ) {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/components/PasswordBottomSheet.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/components/PasswordBottomSheet.kt
@@ -71,7 +71,7 @@ fun PasswordBottomSheet(isVisible: () -> Boolean, transferPassword: () -> String
             LargeButton(
                 modifier = it,
                 title = stringResource(R.string.contentDescriptionButtonClose),
-                style = ButtonType.SECONDARY,
+                style = ButtonType.Secondary,
                 onClick = closeBottomSheet,
             )
         },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferNavHost.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferNavHost.kt
@@ -34,7 +34,11 @@ import io.sentry.Sentry
 import io.sentry.SentryLevel
 
 @Composable
-fun NewTransferNavHost(navController: NavHostController, closeActivity: () -> Unit) {
+fun NewTransferNavHost(
+    navController: NavHostController,
+    closeActivity: () -> Unit,
+    closeActivityAndPromptForValidation: () -> Unit,
+) {
 
     NavHost(navController, NewTransferNavigation.startDestination) {
         composable<ImportFilesDestination> {
@@ -51,7 +55,7 @@ fun NewTransferNavHost(navController: NavHostController, closeActivity: () -> Un
         composable<ValidateUserEmailDestination> {
             val args = it.toRoute<ValidateUserEmailDestination>()
             ValidateUserEmailScreen(
-                closeActivity = closeActivity,
+                closeActivity = closeActivityAndPromptForValidation,
                 navigateBack = { navController.popBackStack() },
                 navigateToUploadInProgress = { totalSize ->
                     navController.navigate(UploadProgressDestination(TransferTypeUi.Mail, totalSize, args.recipients))

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferScreen.kt
@@ -49,7 +49,7 @@ fun ConfirmLeavingDialog(onLeave: () -> Unit, onCancel: () -> Unit) {
         positiveButton = {
             SmallButton(
                 title = stringResource(R.string.newTransferLeavingDialogPositiveButton),
-                style = ButtonType.ERROR,
+                style = ButtonType.ERROR_TEXT,
                 onClick = onLeave,
             )
         },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferScreen.kt
@@ -36,7 +36,11 @@ fun NewTransferScreen(closeActivity: () -> Unit) {
     val navController = rememberNavController()
     var displayConfirmationDialog by rememberSaveable { mutableStateOf(false) }
 
-    NewTransferNavHost(navController, closeActivity = { displayConfirmationDialog = true })
+    NewTransferNavHost(
+        navController,
+        closeActivity = closeActivity,
+        closeActivityAndPromptForValidation = { displayConfirmationDialog = true },
+    )
 
     if (displayConfirmationDialog) ConfirmLeavingDialog(onLeave = closeActivity, onCancel = { displayConfirmationDialog = false })
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferScreen.kt
@@ -18,20 +18,56 @@
 package com.infomaniak.swisstransfer.ui.screen.newtransfer
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
 import androidx.navigation.compose.rememberNavController
+import com.infomaniak.swisstransfer.R
+import com.infomaniak.swisstransfer.ui.components.ButtonType
+import com.infomaniak.swisstransfer.ui.components.SmallButton
+import com.infomaniak.swisstransfer.ui.components.SwissTransferAlertDialog
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
 
 @Composable
 fun NewTransferScreen(closeActivity: () -> Unit) {
     val navController = rememberNavController()
-    NewTransferNavHost(navController, closeActivity)
+    var displayConfirmationDialog by rememberSaveable { mutableStateOf(false) }
+
+    NewTransferNavHost(navController, closeActivity = { displayConfirmationDialog = true })
+
+    if (displayConfirmationDialog) ConfirmLeavingDialog(onLeave = closeActivity, onCancel = { displayConfirmationDialog = false })
+}
+
+@Composable
+fun ConfirmLeavingDialog(onLeave: () -> Unit, onCancel: () -> Unit) {
+    SwissTransferAlertDialog(
+        titleRes = R.string.newTransferConfirmLeavingDialogTitle,
+        descriptionRes = R.string.newTransferLeavingDialogDescription,
+        positiveButton = {
+            SmallButton(
+                title = stringResource(R.string.newTransferLeavingDialogPositiveButton),
+                style = ButtonType.ERROR,
+                onClick = onLeave,
+            )
+        },
+        negativeButton = {
+            SmallButton(
+                title = stringResource(R.string.newTransferLeavingDialogNegativeButton),
+                style = ButtonType.TERTIARY,
+                onClick = onCancel,
+            )
+        },
+        onDismiss = onCancel,
+    )
 }
 
 @PreviewAllWindows
 @Composable
-private fun NewTransferPreview() {
+private fun Preview() {
     SwissTransferTheme {
-        NewTransferScreen {}
+        ConfirmLeavingDialog({}, {})
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferScreen.kt
@@ -53,7 +53,7 @@ fun ConfirmLeavingDialog(onLeave: () -> Unit, onCancel: () -> Unit) {
         positiveButton = {
             SmallButton(
                 title = stringResource(R.string.newTransferLeavingDialogPositiveButton),
-                style = ButtonType.ERROR_TEXT,
+                style = ButtonType.DESTRUCTIVE_TEXT,
                 onClick = onLeave,
             )
         },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferScreen.kt
@@ -53,14 +53,14 @@ fun ConfirmLeavingDialog(onLeave: () -> Unit, onCancel: () -> Unit) {
         positiveButton = {
             SmallButton(
                 title = stringResource(R.string.newTransferLeavingDialogPositiveButton),
-                style = ButtonType.DESTRUCTIVE_TEXT,
+                style = ButtonType.DestructiveText,
                 onClick = onLeave,
             )
         },
         negativeButton = {
             SmallButton(
                 title = stringResource(R.string.newTransferLeavingDialogNegativeButton),
-                style = ButtonType.TERTIARY,
+                style = ButtonType.Tertiary,
                 onClick = onCancel,
             )
         },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -18,6 +18,7 @@
 package com.infomaniak.swisstransfer.ui.screen.newtransfer.importfiles
 
 import android.net.Uri
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
@@ -99,6 +100,8 @@ fun ImportFilesScreen(
         },
         resetSendActionResult = importFilesViewModel::resetSendActionResult,
     )
+
+    BackHandler { closeActivity() } // Closing the activity like other screens will prompt the user to be sure he wants to leave
 
     val transferOptionsCallbacks = importFilesViewModel.getTransferOptionsCallbacks(
         transferOptionsStates = {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -18,7 +18,6 @@
 package com.infomaniak.swisstransfer.ui.screen.newtransfer.importfiles
 
 import android.net.Uri
-import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
@@ -100,8 +99,6 @@ fun ImportFilesScreen(
         },
         resetSendActionResult = importFilesViewModel::resetSendActionResult,
     )
-
-    BackHandler { closeActivity() } // Closing the activity like other screens will prompt the user to be sure he wants to leave
 
     val transferOptionsCallbacks = importFilesViewModel.getTransferOptionsCallbacks(
         transferOptionsStates = {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -444,7 +444,7 @@ private fun SendButton(
     LargeButton(
         modifier = modifier,
         title = stringResource(R.string.transferSendButton),
-        style = ButtonType.PRIMARY,
+        style = ButtonType.Primary,
         showIndeterminateProgress = { sendStatus() == SendStatus.Pending },
         enabled = { importedFiles().isNotEmpty() && !isImporting && areEmailsCorrects() && sendStatus().canEnableButton() },
         progress = progress,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/components/PasswordOptionAlertDialog.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/components/PasswordOptionAlertDialog.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.MatomoSwissTransfer.toFloat
 import com.infomaniak.swisstransfer.ui.components.SwissTransferAlertDialog
+import com.infomaniak.swisstransfer.ui.components.SwissTransferAlertDialogDefaults
 import com.infomaniak.swisstransfer.ui.components.SwissTransferTextField
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.importfiles.PasswordTransferOption
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.upload.components.WeightOneSpacer
@@ -72,9 +73,14 @@ fun PasswordOptionAlertDialog(
     SwissTransferAlertDialog(
         titleRes = R.string.settingsOptionPassword,
         descriptionRes = R.string.settingsPasswordDescription,
+        positiveButton = {
+            SwissTransferAlertDialogDefaults.confirmButton(
+                isEnabled = { !isPasswordActivated || isPasswordValid() },
+                onClick = ::onConfirmButtonClicked,
+            )
+        },
+        negativeButton = { SwissTransferAlertDialogDefaults.cancelButton(onClick = ::onDismiss) },
         onDismiss = ::onDismiss,
-        onConfirmation = ::onConfirmButtonClicked,
-        isConfirmButtonEnabled = { !isPasswordActivated || isPasswordValid() },
     ) {
         ActivatePasswordSwitch(isChecked = isPasswordActivated, onCheckedChange = { isPasswordActivated = it })
         Spacer(Modifier.height(Margin.Medium))

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/components/PasswordOptionAlertDialog.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/components/PasswordOptionAlertDialog.kt
@@ -74,12 +74,12 @@ fun PasswordOptionAlertDialog(
         titleRes = R.string.settingsOptionPassword,
         descriptionRes = R.string.settingsPasswordDescription,
         positiveButton = {
-            SwissTransferAlertDialogDefaults.confirmButton(
+            SwissTransferAlertDialogDefaults.ConfirmButton(
                 isEnabled = { !isPasswordActivated || isPasswordValid() },
                 onClick = ::onConfirmButtonClicked,
             )
         },
-        negativeButton = { SwissTransferAlertDialogDefaults.cancelButton(onClick = ::onDismiss) },
+        negativeButton = { SwissTransferAlertDialogDefaults.CancelButton(onClick = ::onDismiss) },
         onDismiss = ::onDismiss,
     ) {
         ActivatePasswordSwitch(isChecked = isPasswordActivated, onCheckedChange = { isPasswordActivated = it })

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadErrorScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadErrorScreen.kt
@@ -48,7 +48,7 @@ fun UploadErrorScreen(
             LargeButton(
                 modifier = it,
                 title = stringResource(R.string.buttonEditTransfer),
-                style = ButtonType.SECONDARY,
+                style = ButtonType.Secondary,
                 onClick = { uploadProgressViewModel.removeAllUploadSession(onCompletion = navigateBackToImportFiles) },
             )
         }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
@@ -168,7 +168,7 @@ private fun CancelUploadBottomSheet(onCancel: () -> Unit, closeButtonSheet: () -
             LargeButton(
                 title = stringResource(R.string.uploadCancelConfirmBottomSheetCancel),
                 modifier = it,
-                style = ButtonType.ERROR,
+                style = ButtonType.DESTRUCTIVE,
                 onClick = onCancel,
             )
         },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
@@ -168,7 +168,7 @@ private fun CancelUploadBottomSheet(onCancel: () -> Unit, closeButtonSheet: () -
             LargeButton(
                 title = stringResource(R.string.uploadCancelConfirmBottomSheetCancel),
                 modifier = it,
-                style = ButtonType.DESTRUCTIVE,
+                style = ButtonType.Destructive,
                 onClick = onCancel,
             )
         },
@@ -176,7 +176,7 @@ private fun CancelUploadBottomSheet(onCancel: () -> Unit, closeButtonSheet: () -
             LargeButton(
                 title = stringResource(R.string.uploadCancelConfirmBottomSheetClose),
                 modifier = it,
-                style = ButtonType.TERTIARY,
+                style = ButtonType.Tertiary,
                 onClick = closeButtonSheet,
             )
         },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadSuccessQrScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadSuccessQrScreen.kt
@@ -51,7 +51,7 @@ fun UploadSuccessQrScreen(transferType: TransferTypeUi, transferUrl: String, clo
         bottomButton = {
             LargeButton(
                 modifier = it,
-                style = ButtonType.PRIMARY,
+                style = ButtonType.Primary,
                 title = stringResource(R.string.buttonFinished),
                 onClick = closeActivity,
             )

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/components/ShareAndCopyButtons.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/components/ShareAndCopyButtons.kt
@@ -80,7 +80,7 @@ private fun RowScope.ShareCopyButton(icon: ImageVector, @StringRes textRes: Int,
     Button(
         modifier = Modifier.weight(1.0f),
         shape = CustomShapes.MEDIUM,
-        colors = ButtonType.SECONDARY.buttonColors(),
+        colors = ButtonType.Secondary.buttonColors(),
         contentPadding = PaddingValues(vertical = Margin.Medium),
         onClick = onClick,
     ) {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/validateemail/components/ResendCodeCountDownButton.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/validateemail/components/ResendCodeCountDownButton.kt
@@ -75,7 +75,7 @@ fun ResendCodeCountDownButton(modifier: Modifier = Modifier, onResendEmailCode: 
         LargeButton(
             modifier = modifier,
             title = stringResource(R.string.validateMailResendCode),
-            style = ButtonType.TERTIARY,
+            style = ButtonType.Tertiary,
             onClick = {
                 startTimer()
                 onResendEmailCode()
@@ -86,7 +86,7 @@ fun ResendCodeCountDownButton(modifier: Modifier = Modifier, onResendEmailCode: 
         LargeButton(
             modifier = modifier,
             title = stringResource(R.string.validateMailResendCodeTemplate, timeLeft),
-            style = ButtonType.TERTIARY,
+            style = ButtonType.Tertiary,
             onClick = {},
             enabled = { false }
         )

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -53,6 +53,10 @@
     <string name="messageHeader">Nachricht:</string>
     <string name="myFilesTitle">Meine Dateien</string>
     <string name="networkUnavailable">Netzwerk nicht verfügbar</string>
+    <string name="newTransferConfirmLeavingDialogTitle">Ups, willst du wirklich abbrechen?</string>
+    <string name="newTransferLeavingDialogDescription">Dein Transfer ist fast fertig. Bist du sicher, dass du alles rückgängig machen willst?</string>
+    <string name="newTransferLeavingDialogNegativeButton">Nein, weiter</string>
+    <string name="newTransferLeavingDialogPositiveButton">Ja, abbrechen</string>
     <string name="noFileDescription">Fügt bis zu 50 GB an Dateien hinzu</string>
     <string name="noFileTitle">Keine Datei, keine Übertragung!</string>
     <string name="noSettingsSelectedDescription">Wählt einen Parameter zur Anzeige aus</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -53,6 +53,10 @@
     <string name="messageHeader">Mensaje:</string>
     <string name="myFilesTitle">Mis archivos</string>
     <string name="networkUnavailable">Red no disponible</string>
+    <string name="newTransferConfirmLeavingDialogTitle">Ups, ¿realmente quieres cancelar?</string>
+    <string name="newTransferLeavingDialogDescription">Tu traslado está casi listo. ¿Estás seguro de que quieres cancelarlo?</string>
+    <string name="newTransferLeavingDialogNegativeButton">No, continúe</string>
+    <string name="newTransferLeavingDialogPositiveButton">Sí, cancelar</string>
     <string name="noFileDescription">Añade hasta 50 GB de archivos</string>
     <string name="noFileTitle">Si no hay archivo, no hay transferencia.</string>
     <string name="noSettingsSelectedDescription">Selecciona un parámetro para su visualización</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -54,6 +54,10 @@
     <string name="messageHeader">Message :</string>
     <string name="myFilesTitle">Mes fichiers</string>
     <string name="networkUnavailable">Réseau indisponible</string>
+    <string name="newTransferConfirmLeavingDialogTitle">Oups, tu veux vraiment annuler ?</string>
+    <string name="newTransferLeavingDialogDescription">Ton transfert est presque prêt. Es-tu sûr de vouloir tout annuler ?</string>
+    <string name="newTransferLeavingDialogNegativeButton">Non, continuer</string>
+    <string name="newTransferLeavingDialogPositiveButton">Oui, annuler</string>
     <string name="noFileDescription">Ajoute jusqu’à 50 Go de fichiers</string>
     <string name="noFileTitle">Pas de fichier, pas de transfert !</string>
     <string name="noSettingsSelectedDescription">Sélectionne un paramètre pour l’afficher</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -53,6 +53,10 @@
     <string name="messageHeader">Messaggio:</string>
     <string name="myFilesTitle">I miei file</string>
     <string name="networkUnavailable">Rete non disponibile</string>
+    <string name="newTransferConfirmLeavingDialogTitle">Ops, vuoi davvero cancellarti?</string>
+    <string name="newTransferLeavingDialogDescription">Il trasferimento è quasi pronto. Sei sicuro di volerlo annullare?</string>
+    <string name="newTransferLeavingDialogNegativeButton">No, continua</string>
+    <string name="newTransferLeavingDialogPositiveButton">Sì, annulla</string>
     <string name="noFileDescription">Aggiungere fino a 50 GB di file</string>
     <string name="noFileTitle">Nessun file, nessun trasferimento!</string>
     <string name="noSettingsSelectedDescription">Seleziona un parametro da visualizzare</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,10 @@
     <string name="messageHeader">Message:</string>
     <string name="myFilesTitle">My files</string>
     <string name="networkUnavailable">Network unavailable</string>
+    <string name="newTransferConfirmLeavingDialogTitle">Oops, do you really want to cancel?</string>
+    <string name="newTransferLeavingDialogDescription">Your transfer is almost ready. Are you sure you want to cancel it?</string>
+    <string name="newTransferLeavingDialogNegativeButton">No, continue</string>
+    <string name="newTransferLeavingDialogPositiveButton">Yes, cancel</string>
     <string name="noFileDescription">Add up to 50 GB of files</string>
     <string name="noFileTitle">No file, no transfer!</string>
     <string name="noSettingsSelectedDescription">Select a parameter to display it</string>


### PR DESCRIPTION
Don't let them escape!

This required me to refactor the dialog composable we already have to have greater control over the buttons. I opted for a more standard interfacing logic instead of adding a *lot* of parameters. We can now compose the dialog with buttons. There's still two constant buttons already defined for the standard cases.

This PR also required to add stacking buttons in dialogs when the buttons are too wide which required to change the design of the buttons for plain text buttons like the native material theme so they are not misaligned when stacked.

Depends on #254