### PR TITLE
fix: Make transfer lists stop only at the very edge of the lazy column

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransferItemList.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransferItemList.kt
@@ -19,8 +19,6 @@ package com.infomaniak.swisstransfer.ui.components.transfer
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -61,10 +59,8 @@ fun TransferItemList(
         verticalArrangement = Arrangement.spacedBy(Margin.Medium),
         contentPadding = contentPadding,
     ) {
-        item {
-            Spacer(Modifier.height(Margin.Mini))
-            Text(text = stringResource(titleRes), style = SwissTransferTheme.typography.h1)
-        }
+
+        item { Text(text = stringResource(titleRes), style = SwissTransferTheme.typography.h1) }
 
         items(
             count = getTransfers().count(),

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransferItemList.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransferItemList.kt
@@ -19,6 +19,8 @@ package com.infomaniak.swisstransfer.ui.components.transfer
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -44,6 +46,7 @@ fun TransferItemList(
     getTransfers: () -> List<TransferUi>,
     onSwiped: (String) -> Unit,
     onClick: (TransferUi) -> Unit,
+    contentPadding: PaddingValues = PaddingValues(),
 ) {
 
     val selectedTransferUuid = getSelectedTransferUuid()
@@ -56,10 +59,12 @@ fun TransferItemList(
     LazyColumn(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(Margin.Medium),
-        contentPadding = PaddingValues(top = Margin.Mini),
+        contentPadding = contentPadding,
     ) {
-
-        item { Text(text = stringResource(titleRes), style = SwissTransferTheme.typography.h1) }
+        item {
+            Spacer(Modifier.height(Margin.Mini))
+            Text(text = stringResource(titleRes), style = SwissTransferTheme.typography.h1)
+        }
 
         items(
             count = getTransfers().count(),

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransferItemList.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransferItemList.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.infomaniak.multiplatform_swisstransfer.common.interfaces.ui.TransferUi
@@ -38,7 +37,6 @@ import com.infomaniak.swisstransfer.ui.utils.PreviewLightAndDark
 
 @Composable
 fun TransferItemList(
-    modifier: Modifier = Modifier,
     direction: TransferDirection,
     getSelectedTransferUuid: () -> String?,
     getTransfers: () -> List<TransferUi>,
@@ -55,7 +53,6 @@ fun TransferItemList(
     }
 
     LazyColumn(
-        modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(Margin.Medium),
         contentPadding = contentPadding,
     ) {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransfersListWithExpiredBottomSheet.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransfersListWithExpiredBottomSheet.kt
@@ -18,14 +18,12 @@
 package com.infomaniak.swisstransfer.ui.components.transfer
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.infomaniak.multiplatform_swisstransfer.common.interfaces.ui.TransferUi
 import com.infomaniak.multiplatform_swisstransfer.common.models.TransferDirection
@@ -58,7 +56,7 @@ fun TransfersListWithExpiredBottomSheet(
                 navigateToDetails(transfer.uuid)
             }
         },
-        contentPadding = PaddingValues(Margin.Medium),
+        contentPadding = PaddingValues(top = Margin.Large, bottom = Margin.Medium, start = Margin.Medium, end = Margin.Medium),
     )
 
     TransferExpiredBottomSheet(

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransfersListWithExpiredBottomSheet.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransfersListWithExpiredBottomSheet.kt
@@ -17,6 +17,7 @@
  */
 package com.infomaniak.swisstransfer.ui.components.transfer
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -46,7 +47,6 @@ fun TransfersListWithExpiredBottomSheet(
     var expiredTransfer: TransferUi? by rememberSaveable { mutableStateOf(null) }
 
     TransferItemList(
-        modifier = Modifier.padding(Margin.Medium),
         direction = direction,
         getSelectedTransferUuid = getSelectedTransferUuid,
         getTransfers = getTransfers,
@@ -57,7 +57,8 @@ fun TransfersListWithExpiredBottomSheet(
             } else {
                 navigateToDetails(transfer.uuid)
             }
-        }
+        },
+        contentPadding = PaddingValues(Margin.Medium),
     )
 
     TransferExpiredBottomSheet(


### PR DESCRIPTION
There was some padding stopping the list from ever reaching the vertical edges of the lazy column, I removed it.