### PR TITLE
feat: Split app integrity logic from send transfer logic

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferSendManager.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferSendManager.kt
@@ -111,7 +111,7 @@ class TransferSendManager @Inject constructor(
                 )
             }
 
-            attestationToken?.let { onSuccess(it) } ?: onRefused.invoke()
+            attestationToken?.let(onSuccess) ?: onRefused()
         }.onFailure {
             onFailure.invoke(it)
         }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferSendManager.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferSendManager.kt
@@ -57,12 +57,8 @@ class TransferSendManager @Inject constructor(
         _integrityCheckResult.value = AppIntegrityResult.Ongoing
 
         withIntegrityToken(
-            onSuccess = { attestationToken ->
-                sendTransfer(newUploadSession, attestationToken)
-            },
-            onRefused = {
-                _integrityCheckResult.value = AppIntegrityResult.Fail
-            },
+            onSuccess = { attestationToken -> sendTransfer(newUploadSession, attestationToken) },
+            onRefused = { _integrityCheckResult.value = AppIntegrityResult.Fail },
             onFailure = { exception ->
                 if (exception !is CancellationException) {
                     SentryLog.e(TAG, "Integrity token received an exception", exception)

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferSendManager.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferSendManager.kt
@@ -119,7 +119,7 @@ class TransferSendManager @Inject constructor(
         coroutineScope {
             appIntegrityManager.requestClassicIntegrityVerdictToken(
                 onSuccess = { token ->
-                    SentryLog.i(APP_INTEGRITY_MANAGER_TAG, "request for app integrity token successful $token")
+                    SentryLog.i(APP_INTEGRITY_MANAGER_TAG, "request for app integrity token successful")
                     launch { attestationToken = getApiIntegrityVerdict(appIntegrityManager, token) }
                 },
                 onFailure = {},

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferSendManager.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferSendManager.kt
@@ -117,18 +117,20 @@ class TransferSendManager @Inject constructor(
         }
     }
 
-    private suspend fun requestAppIntegrityToken(appIntegrityManager: AppIntegrityManager): String? = coroutineScope {
+    private suspend fun requestAppIntegrityToken(appIntegrityManager: AppIntegrityManager): String? {
         var attestationToken: String? = null
 
-        appIntegrityManager.requestClassicIntegrityVerdictToken(
-            onSuccess = { token ->
-                SentryLog.i(APP_INTEGRITY_MANAGER_TAG, "request for app integrity token successful $token")
-                launch { attestationToken = getApiIntegrityVerdict(appIntegrityManager, token) }
-            },
-            onFailure = {},
-        )
+        coroutineScope {
+            appIntegrityManager.requestClassicIntegrityVerdictToken(
+                onSuccess = { token ->
+                    SentryLog.i(APP_INTEGRITY_MANAGER_TAG, "request for app integrity token successful $token")
+                    launch { attestationToken = getApiIntegrityVerdict(appIntegrityManager, token) }
+                },
+                onFailure = {},
+            )
+        }
 
-        return@coroutineScope attestationToken
+        return attestationToken
     }
 
     private suspend fun getApiIntegrityVerdict(appIntegrityManager: AppIntegrityManager, appIntegrityToken: String): String? {


### PR DESCRIPTION
I'll later need to call two different logics with an integrity token so I refactored the code to be able to easily reuse the integrity token for any purpose