### PR TITLE
fix: ShareAndCopy spacing

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadSuccessQrScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadSuccessQrScreen.kt
@@ -61,7 +61,7 @@ fun UploadSuccessQrScreen(transferType: TransferTypeUi, transferUrl: String, clo
             SuccessMessage(transferType, transferUrl)
 
             ShareAndCopyButtons(
-                modifier = Modifier.padding(bottom = Margin.Medium, top = Margin.Mini),
+                modifier = Modifier.padding(bottom = Margin.Micro, top = Margin.Mini),
                 transferLink = transferUrl,
                 snackbarHostState = snackbarHostState,
             )


### PR DESCRIPTION
The spacing between the ShareAndCopy buttons and the "finish" button wasn't coherent with the usually stacked buttons and with the spec. I fixed it