### PR TITLE
feat: Opt-out of Matomo & Sentry

### DIFF
--- a/Core2/Matomo/build.gradle.kts
+++ b/Core2/Matomo/build.gradle.kts
@@ -43,4 +43,5 @@ android {
 
 dependencies {
     api(core2.matomo)
+    implementation(core2.splitties.appctx)
 }

--- a/Core2/Matomo/src/main/java/com/infomaniak/core2/matomo/Matomo.kt
+++ b/Core2/Matomo/src/main/java/com/infomaniak/core2/matomo/Matomo.kt
@@ -25,16 +25,17 @@ import org.matomo.sdk.Tracker
 import org.matomo.sdk.TrackerBuilder
 import org.matomo.sdk.extra.DownloadTracker
 import org.matomo.sdk.extra.TrackHelper
+import splitties.init.appCtx
 
 interface Matomo {
 
-    val Context.tracker: Tracker
+    val tracker: Tracker
     val siteId: Int
 
-    fun Context.buildTracker(shouldOptOut: Boolean = false): Tracker {
-        return TrackerBuilder(BuildConfig.MATOMO_URL, siteId, "AndroidTracker").build(Matomo.getInstance(this)).also {
+    fun buildTracker(shouldOptOut: Boolean = false): Tracker {
+        return TrackerBuilder(BuildConfig.MATOMO_URL, siteId, "AndroidTracker").build(Matomo.getInstance(appCtx)).also {
             // Put a tracker on app installs to have statistics on the number of times the app is installed or updated
-            TrackHelper.track().download().identifier(DownloadTracker.Extra.ApkChecksum(this)).with(it)
+            TrackHelper.track().download().identifier(DownloadTracker.Extra.ApkChecksum(appCtx)).with(it)
             it.isOptOut = shouldOptOut
         }
     }
@@ -88,7 +89,7 @@ interface Matomo {
     fun Boolean.toFloat() = if (this) 1.0f else 0.0f
 
     fun shouldOptOut(context: Context, shouldOptOut: Boolean) {
-        context.tracker.isOptOut = shouldOptOut
+        tracker.isOptOut = shouldOptOut
     }
 
     enum class TrackerAction {

--- a/Core2/Matomo/src/main/java/com/infomaniak/core2/matomo/Matomo.kt
+++ b/Core2/Matomo/src/main/java/com/infomaniak/core2/matomo/Matomo.kt
@@ -18,7 +18,6 @@
 package com.infomaniak.core2.matomo
 
 import android.app.Activity
-import android.content.Context
 import android.util.Log
 import org.matomo.sdk.Matomo
 import org.matomo.sdk.Tracker
@@ -40,7 +39,7 @@ interface Matomo {
         }
     }
 
-    fun Context.addTrackingCallbackForDebugLog() {
+    fun addTrackingCallbackForDebugLog() {
         if (BuildConfig.DEBUG) {
             tracker.addTrackingCallback { trackMe ->
                 trackMe.also {
@@ -58,7 +57,7 @@ interface Matomo {
         }
     }
 
-    fun Context.trackUserId(userId: Int) {
+    fun trackUserId(userId: Int) {
         tracker.userId = userId.toString()
     }
 
@@ -67,13 +66,13 @@ interface Matomo {
         TrackHelper.track().screen(this).title(this::class.java.simpleName).with(tracker)
     }
 
-    fun Context.trackScreen(path: String, title: String) {
+    fun trackScreen(path: String, title: String) {
         TrackHelper.track().screen(path).title(title).with(tracker)
     }
     //endregion
 
     //region Track events
-    fun Context.trackEvent(category: String, name: String, action: TrackerAction = TrackerAction.CLICK, value: Float? = null) {
+    fun trackEvent(category: String, name: String, action: TrackerAction = TrackerAction.CLICK, value: Float? = null) {
         TrackHelper.track()
             .event(category, action.toString())
             .name(name)
@@ -81,16 +80,12 @@ interface Matomo {
             .with(tracker)
     }
 
-    fun Context.trackAccountEvent(name: String, action: TrackerAction = TrackerAction.CLICK, value: Float? = null) {
+    fun trackAccountEvent(name: String, action: TrackerAction = TrackerAction.CLICK, value: Float? = null) {
         trackEvent("account", name, action, value)
     }
     //endregion
 
     fun Boolean.toFloat() = if (this) 1.0f else 0.0f
-
-    fun shouldOptOut(context: Context, shouldOptOut: Boolean) {
-        tracker.isOptOut = shouldOptOut
-    }
 
     enum class TrackerAction {
         CLICK,

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -154,6 +154,7 @@ dependencies {
     implementation(libs.recaptcha)
     implementation(libs.workmanager)
     implementation(core2.splitties.toast)
+    implementation(libs.androidx.datastore.preferences)
 
     // Test
     testImplementation(core2.junit)

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/MainApplication.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/MainApplication.kt
@@ -26,7 +26,7 @@ import com.infomaniak.swisstransfer.BuildConfig
 import com.infomaniak.swisstransfer.ui.utils.AccountUtils
 import com.infomaniak.swisstransfer.ui.utils.DataManagementPreferences
 import com.infomaniak.swisstransfer.ui.utils.dataManagementDataStore
-import com.infomaniak.swisstransfer.ui.utils.getValue
+import com.infomaniak.swisstransfer.ui.utils.getPreference
 import dagger.hilt.android.HiltAndroidApp
 import io.sentry.SentryEvent
 import io.sentry.SentryOptions
@@ -75,7 +75,7 @@ class MainApplication : Application(), Configuration.Provider {
                  * - User deactivated Sentry tracking in DataManagement settings
                  * - The exception was a NetworkException, and we don't want to send them to Sentry
                  */
-                val isSentryAuthorized = dataManagementDataStore.getValue(DataManagementPreferences.IsSentryAuthorized)
+                val isSentryAuthorized = dataManagementDataStore.getPreference(DataManagementPreferences.IsSentryAuthorized)
                 if (!BuildConfig.DEBUG && isSentryAuthorized && !isNetworkException) event else null
             }
         }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/MainApplication.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/MainApplication.kt
@@ -24,6 +24,9 @@ import com.infomaniak.multiplatform_swisstransfer.managers.AccountManager
 import com.infomaniak.multiplatform_swisstransfer.managers.TransferManager
 import com.infomaniak.swisstransfer.BuildConfig
 import com.infomaniak.swisstransfer.ui.utils.AccountUtils
+import com.infomaniak.swisstransfer.ui.utils.DataManagementPreferences
+import com.infomaniak.swisstransfer.ui.utils.dataManagementDataStore
+import com.infomaniak.swisstransfer.ui.utils.getValue
 import dagger.hilt.android.HiltAndroidApp
 import io.sentry.SentryEvent
 import io.sentry.SentryOptions
@@ -64,9 +67,16 @@ class MainApplication : Application(), Configuration.Provider {
 
         SentryAndroid.init(this) { options: SentryAndroidOptions ->
             // Register the callback as an option
-            options.beforeSend = SentryOptions.BeforeSendCallback { event: SentryEvent?, _: Any? ->
-                // If the application is in debug mode, discard the events
-                if (BuildConfig.DEBUG) null else event
+            options.beforeSend = SentryOptions.BeforeSendCallback { event: SentryEvent, _: Any? ->
+                val isNetworkException = event.exceptions?.any { it.type == "ApiController\$NetworkException" } ?: false
+                /**
+                 * Reasons to discard Sentry events :
+                 * - Application is in Debug mode
+                 * - User deactivated Sentry tracking in DataManagement settings
+                 * - The exception was a NetworkException, and we don't want to send them to Sentry
+                 */
+                val isSentryAuthorized = dataManagementDataStore.getValue(DataManagementPreferences.IsSentryAuthorized)
+                if (!BuildConfig.DEBUG && isSentryAuthorized && !isNetworkException) event else null
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/MatomoSwissTransfer.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/MatomoSwissTransfer.kt
@@ -21,13 +21,13 @@ import android.content.Context
 import com.infomaniak.core2.matomo.Matomo
 import com.infomaniak.swisstransfer.ui.utils.DataManagementPreferences
 import com.infomaniak.swisstransfer.ui.utils.dataManagementDataStore
-import com.infomaniak.swisstransfer.ui.utils.getValue
+import com.infomaniak.swisstransfer.ui.utils.getPreference
 import org.matomo.sdk.Tracker
 
 object MatomoSwissTransfer : Matomo {
 
     override val Context.tracker: Tracker
-        get() = buildTracker(shouldOptOut = !dataManagementDataStore.getValue(DataManagementPreferences.IsMatomoAuthorized))
+        get() = buildTracker(shouldOptOut = !dataManagementDataStore.getPreference(DataManagementPreferences.IsMatomoAuthorized))
 
     override val siteId: Int = 24
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/MatomoSwissTransfer.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/MatomoSwissTransfer.kt
@@ -17,17 +17,34 @@
  */
 package com.infomaniak.swisstransfer.ui
 
-import android.content.Context
 import com.infomaniak.core2.matomo.Matomo
 import com.infomaniak.swisstransfer.ui.utils.DataManagementPreferences
 import com.infomaniak.swisstransfer.ui.utils.dataManagementDataStore
+import com.infomaniak.swisstransfer.ui.utils.get
 import com.infomaniak.swisstransfer.ui.utils.getPreference
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.matomo.sdk.Tracker
+import splitties.init.appCtx
 
 object MatomoSwissTransfer : Matomo {
 
-    override val Context.tracker: Tracker
-        get() = buildTracker(shouldOptOut = !dataManagementDataStore.getPreference(DataManagementPreferences.IsMatomoAuthorized))
+    private val scope = CoroutineScope(Dispatchers.Default)
+
+    override val tracker: Tracker = with(appCtx) {
+        buildTracker(shouldOptOut = dataManagementDataStore.getPreference(DataManagementPreferences.IsMatomoAuthorized).not())
+    }
 
     override val siteId: Int = 24
+
+    init {
+        scope.launch {
+            with(appCtx) {
+                dataManagementDataStore.data.collect {
+                    tracker.isOptOut = it[DataManagementPreferences.IsMatomoAuthorized].not()
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/MatomoSwissTransfer.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/MatomoSwissTransfer.kt
@@ -19,10 +19,15 @@ package com.infomaniak.swisstransfer.ui
 
 import android.content.Context
 import com.infomaniak.core2.matomo.Matomo
+import com.infomaniak.swisstransfer.ui.utils.DataManagementPreferences
+import com.infomaniak.swisstransfer.ui.utils.dataManagementDataStore
+import com.infomaniak.swisstransfer.ui.utils.getValue
 import org.matomo.sdk.Tracker
 
 object MatomoSwissTransfer : Matomo {
 
-    override val Context.tracker: Tracker get() = buildTracker() // TODO: Fetch appSettings for opt-out
+    override val Context.tracker: Tracker
+        get() = buildTracker(shouldOptOut = !dataManagementDataStore.getValue(DataManagementPreferences.IsMatomoAuthorized))
+
     override val siteId: Int = 24
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsDataManagementMatomoScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsDataManagementMatomoScreen.kt
@@ -24,13 +24,12 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.components.SwissTransferTopAppBar
 import com.infomaniak.swisstransfer.ui.components.TopAppBarButtons
@@ -40,15 +39,28 @@ import com.infomaniak.swisstransfer.ui.screen.main.components.SmallWindowTopAppB
 import com.infomaniak.swisstransfer.ui.theme.Margin
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.*
-import kotlinx.coroutines.launch
 
 @Composable
-fun SettingsDataManagementMatomoScreen(navigateBack: (() -> Unit)?) {
-    val scope = rememberCoroutineScope()
-    val dataStore = LocalContext.current.dataManagementDataStore
+fun SettingsDataManagementMatomoScreen(
+    navigateBack: (() -> Unit)?,
+    settingsMatomoViewModel: SettingsMatomoViewModel = hiltViewModel<SettingsMatomoViewModel>()
+) {
+    val isMatomoAuthorized by settingsMatomoViewModel.isMatomoAuthorized.collectAsStateWithLifecycle()
 
-    val isMatomoAuthorized by dataStore.collectAsStateWithLifecycle(DataManagementPreferences.IsMatomoAuthorized, false)
+    SettingsDataManagementMatomoScreen(
+        navigateBack = navigateBack,
+        isMatomoAuthorized = { isMatomoAuthorized },
+        setMatomoAuthorization = { settingsMatomoViewModel.setMatomoAuthorization(it) }
+    )
+}
 
+
+@Composable
+fun SettingsDataManagementMatomoScreen(
+    navigateBack: (() -> Unit)?,
+    isMatomoAuthorized: () -> Boolean,
+    setMatomoAuthorization: (Boolean) -> Unit,
+) {
     SmallWindowTopAppBarScaffold(
         smallWindowTopAppBar = {
             SwissTransferTopAppBar(
@@ -85,10 +97,8 @@ fun SettingsDataManagementMatomoScreen(navigateBack: (() -> Unit)?) {
                 )
                 Spacer(Modifier.weight(1.0f))
                 Switch(
-                    checked = isMatomoAuthorized,
-                    onCheckedChange = {
-                        scope.launch { dataStore.setValue(DataManagementPreferences.IsMatomoAuthorized, it) }
-                    },
+                    checked = isMatomoAuthorized(),
+                    onCheckedChange = { setMatomoAuthorization(it) },
                 )
             }
         }
@@ -100,7 +110,13 @@ fun SettingsDataManagementMatomoScreen(navigateBack: (() -> Unit)?) {
 private fun Preview() {
     SwissTransferTheme {
         Surface {
-            SettingsDataManagementMatomoScreen {}
+            var isMatomoAuthorized by remember { mutableStateOf(true) }
+
+            SettingsDataManagementMatomoScreen(
+                navigateBack = {},
+                isMatomoAuthorized = { isMatomoAuthorized },
+                setMatomoAuthorization = { isMatomoAuthorized = it }
+            )
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsDataManagementMatomoScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsDataManagementMatomoScreen.kt
@@ -26,11 +26,10 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.components.SwissTransferTopAppBar
@@ -40,13 +39,15 @@ import com.infomaniak.swisstransfer.ui.images.illus.matomo.Matomo
 import com.infomaniak.swisstransfer.ui.screen.main.components.SmallWindowTopAppBarScaffold
 import com.infomaniak.swisstransfer.ui.theme.Margin
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
-import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
+import com.infomaniak.swisstransfer.ui.utils.*
+import kotlinx.coroutines.launch
 
 @Composable
 fun SettingsDataManagementMatomoScreen(navigateBack: (() -> Unit)?) {
+    val scope = rememberCoroutineScope()
+    val dataStore = LocalContext.current.dataManagementDataStore
 
-    // TODO: Use real value from Realm, and save it to Realm / anywhere else too.
-    var isMatomoAuthorized by rememberSaveable { mutableStateOf(true) }
+    val isMatomoAuthorized by dataStore.collectAsStateWithLifecycle(DataManagementPreferences.IsMatomoAuthorized, false)
 
     SmallWindowTopAppBarScaffold(
         smallWindowTopAppBar = {
@@ -85,7 +86,9 @@ fun SettingsDataManagementMatomoScreen(navigateBack: (() -> Unit)?) {
                 Spacer(Modifier.weight(1.0f))
                 Switch(
                     checked = isMatomoAuthorized,
-                    onCheckedChange = { isMatomoAuthorized = it },
+                    onCheckedChange = {
+                        scope.launch { dataStore.setValue(DataManagementPreferences.IsMatomoAuthorized, it) }
+                    },
                 )
             }
         }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsDataManagementMatomoScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsDataManagementMatomoScreen.kt
@@ -38,7 +38,7 @@ import com.infomaniak.swisstransfer.ui.images.illus.matomo.Matomo
 import com.infomaniak.swisstransfer.ui.screen.main.components.SmallWindowTopAppBarScaffold
 import com.infomaniak.swisstransfer.ui.theme.Margin
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
-import com.infomaniak.swisstransfer.ui.utils.*
+import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
 
 @Composable
 fun SettingsDataManagementMatomoScreen(

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsDataManagementSentryScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsDataManagementSentryScreen.kt
@@ -26,11 +26,10 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.components.SwissTransferTopAppBar
@@ -40,13 +39,15 @@ import com.infomaniak.swisstransfer.ui.images.illus.sentry.Sentry
 import com.infomaniak.swisstransfer.ui.screen.main.components.SmallWindowTopAppBarScaffold
 import com.infomaniak.swisstransfer.ui.theme.Margin
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
-import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
+import com.infomaniak.swisstransfer.ui.utils.*
+import kotlinx.coroutines.launch
 
 @Composable
 fun SettingsDataManagementSentryScreen(navigateBack: (() -> Unit)?) {
+    val scope = rememberCoroutineScope()
+    val dataStore = LocalContext.current.dataManagementDataStore
 
-    // TODO: Use real value from Realm, and save it to Realm / anywhere else too.
-    var isSentryAuthorized by rememberSaveable { mutableStateOf(true) }
+    val isSentryAuthorized by dataStore.collectAsStateWithLifecycle(DataManagementPreferences.IsSentryAuthorized, false)
 
     SmallWindowTopAppBarScaffold(
         smallWindowTopAppBar = {
@@ -85,7 +86,9 @@ fun SettingsDataManagementSentryScreen(navigateBack: (() -> Unit)?) {
                 Spacer(Modifier.weight(1.0f))
                 Switch(
                     checked = isSentryAuthorized,
-                    onCheckedChange = { isSentryAuthorized = it },
+                    onCheckedChange = {
+                        scope.launch { dataStore.setValue(DataManagementPreferences.IsSentryAuthorized, it) }
+                    },
                 )
             }
         }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsDataManagementSentryScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsDataManagementSentryScreen.kt
@@ -24,13 +24,12 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.components.SwissTransferTopAppBar
 import com.infomaniak.swisstransfer.ui.components.TopAppBarButtons
@@ -39,16 +38,28 @@ import com.infomaniak.swisstransfer.ui.images.illus.sentry.Sentry
 import com.infomaniak.swisstransfer.ui.screen.main.components.SmallWindowTopAppBarScaffold
 import com.infomaniak.swisstransfer.ui.theme.Margin
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
-import com.infomaniak.swisstransfer.ui.utils.*
-import kotlinx.coroutines.launch
+import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
 
 @Composable
-fun SettingsDataManagementSentryScreen(navigateBack: (() -> Unit)?) {
-    val scope = rememberCoroutineScope()
-    val dataStore = LocalContext.current.dataManagementDataStore
+fun SettingsDataManagementSentryScreen(
+    navigateBack: (() -> Unit)?,
+    settingsSentryViewModel: SettingsSentryViewModel = hiltViewModel<SettingsSentryViewModel>()
+) {
+    val isSentryAuthorized by settingsSentryViewModel.isSentryAuthorized.collectAsStateWithLifecycle()
 
-    val isSentryAuthorized by dataStore.collectAsStateWithLifecycle(DataManagementPreferences.IsSentryAuthorized, false)
+    SettingsDataManagementSentryScreen(
+        navigateBack = navigateBack,
+        isSentryAuthorized = { isSentryAuthorized },
+        setSentryAuthorization = { settingsSentryViewModel.setSentryAuthorization(it) }
+    )
+}
 
+@Composable
+fun SettingsDataManagementSentryScreen(
+    navigateBack: (() -> Unit)?,
+    isSentryAuthorized: () -> Boolean,
+    setSentryAuthorization: (Boolean) -> Unit,
+) {
     SmallWindowTopAppBarScaffold(
         smallWindowTopAppBar = {
             SwissTransferTopAppBar(
@@ -85,10 +96,8 @@ fun SettingsDataManagementSentryScreen(navigateBack: (() -> Unit)?) {
                 )
                 Spacer(Modifier.weight(1.0f))
                 Switch(
-                    checked = isSentryAuthorized,
-                    onCheckedChange = {
-                        scope.launch { dataStore.setValue(DataManagementPreferences.IsSentryAuthorized, it) }
-                    },
+                    checked = isSentryAuthorized(),
+                    onCheckedChange = { setSentryAuthorization(it) },
                 )
             }
         }
@@ -100,7 +109,13 @@ fun SettingsDataManagementSentryScreen(navigateBack: (() -> Unit)?) {
 private fun Preview() {
     SwissTransferTheme {
         Surface {
-            SettingsDataManagementSentryScreen {}
+            var isSentryAuthorized by remember { mutableStateOf(true) }
+
+            SettingsDataManagementSentryScreen(
+                navigateBack = {},
+                isSentryAuthorized = { isSentryAuthorized },
+                setSentryAuthorization = { isSentryAuthorized = it }
+            )
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsMatomoViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsMatomoViewModel.kt
@@ -21,14 +21,12 @@ import android.content.Context
 import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.infomaniak.swisstransfer.di.IoDispatcher
 import com.infomaniak.swisstransfer.ui.utils.DataManagementPreferences
 import com.infomaniak.swisstransfer.ui.utils.dataManagementDataStore
 import com.infomaniak.swisstransfer.ui.utils.get
 import com.infomaniak.swisstransfer.ui.utils.set
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -38,14 +36,13 @@ import javax.inject.Inject
 @HiltViewModel
 class SettingsMatomoViewModel @Inject constructor(
     @ApplicationContext private val appContext: Context,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
     val isMatomoAuthorized = appContext.dataManagementDataStore.data
         .map { it[DataManagementPreferences.IsMatomoAuthorized] }
         .stateIn(viewModelScope, SharingStarted.Lazily, false)
 
     fun setMatomoAuthorization(isAuthorized: Boolean) {
-        viewModelScope.launch(ioDispatcher) {
+        viewModelScope.launch {
             appContext.dataManagementDataStore.edit {
                 it[DataManagementPreferences.IsMatomoAuthorized] = isAuthorized
             }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsMatomoViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsMatomoViewModel.kt
@@ -1,0 +1,54 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.swisstransfer.ui.screen.main.settings
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.infomaniak.swisstransfer.di.IoDispatcher
+import com.infomaniak.swisstransfer.ui.utils.DataManagementPreferences
+import com.infomaniak.swisstransfer.ui.utils.dataManagementDataStore
+import com.infomaniak.swisstransfer.ui.utils.get
+import com.infomaniak.swisstransfer.ui.utils.set
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsMatomoViewModel @Inject constructor(
+    @ApplicationContext private val appContext: Context,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : ViewModel() {
+    val isMatomoAuthorized = appContext.dataManagementDataStore.data
+        .map { it[DataManagementPreferences.IsMatomoAuthorized] }
+        .stateIn(viewModelScope, SharingStarted.Lazily, false)
+
+    fun setMatomoAuthorization(isAuthorized: Boolean) {
+        viewModelScope.launch(ioDispatcher) {
+            appContext.dataManagementDataStore.edit {
+                it[DataManagementPreferences.IsMatomoAuthorized] = isAuthorized
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsSentryViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsSentryViewModel.kt
@@ -1,0 +1,54 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.swisstransfer.ui.screen.main.settings
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.infomaniak.swisstransfer.di.IoDispatcher
+import com.infomaniak.swisstransfer.ui.utils.DataManagementPreferences
+import com.infomaniak.swisstransfer.ui.utils.dataManagementDataStore
+import com.infomaniak.swisstransfer.ui.utils.get
+import com.infomaniak.swisstransfer.ui.utils.set
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsSentryViewModel @Inject constructor(
+    @ApplicationContext private val appContext: Context,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : ViewModel() {
+    val isSentryAuthorized = appContext.dataManagementDataStore.data
+        .map { it[DataManagementPreferences.IsSentryAuthorized] }
+        .stateIn(viewModelScope, SharingStarted.Lazily, false)
+
+    fun setSentryAuthorization(isAuthorized: Boolean) {
+        viewModelScope.launch(ioDispatcher) {
+            appContext.dataManagementDataStore.edit {
+                it[DataManagementPreferences.IsSentryAuthorized] = isAuthorized
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsSentryViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/SettingsSentryViewModel.kt
@@ -21,14 +21,12 @@ import android.content.Context
 import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.infomaniak.swisstransfer.di.IoDispatcher
 import com.infomaniak.swisstransfer.ui.utils.DataManagementPreferences
 import com.infomaniak.swisstransfer.ui.utils.dataManagementDataStore
 import com.infomaniak.swisstransfer.ui.utils.get
 import com.infomaniak.swisstransfer.ui.utils.set
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -38,14 +36,13 @@ import javax.inject.Inject
 @HiltViewModel
 class SettingsSentryViewModel @Inject constructor(
     @ApplicationContext private val appContext: Context,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
     val isSentryAuthorized = appContext.dataManagementDataStore.data
         .map { it[DataManagementPreferences.IsSentryAuthorized] }
         .stateIn(viewModelScope, SharingStarted.Lazily, false)
 
     fun setSentryAuthorization(isAuthorized: Boolean) {
-        viewModelScope.launch(ioDispatcher) {
+        viewModelScope.launch {
             appContext.dataManagementDataStore.edit {
                 it[DataManagementPreferences.IsSentryAuthorized] = isAuthorized
             }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/utils/DataManagementPreferences.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/utils/DataManagementPreferences.kt
@@ -1,0 +1,31 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.swisstransfer.ui.utils
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.dataManagementDataStore: DataStore<Preferences> by preferencesDataStore(name = "DataManagementPreferences")
+
+object DataManagementPreferences {
+    data object IsSentryAuthorized : DataStoreValue<Boolean>(booleanPreferencesKey("IsSentryAuthorized"), true)
+    data object IsMatomoAuthorized : DataStoreValue<Boolean>(booleanPreferencesKey("IsMatomoAuthorized"), true)
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/utils/DataManagementPreferences.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/utils/DataManagementPreferences.kt
@@ -26,6 +26,6 @@ import androidx.datastore.preferences.preferencesDataStore
 val Context.dataManagementDataStore: DataStore<Preferences> by preferencesDataStore(name = "DataManagementPreferences")
 
 object DataManagementPreferences {
-    data object IsSentryAuthorized : DataStoreValue<Boolean>(booleanPreferencesKey("IsSentryAuthorized"), true)
-    data object IsMatomoAuthorized : DataStoreValue<Boolean>(booleanPreferencesKey("IsMatomoAuthorized"), true)
+    data object IsSentryAuthorized : DataStorePreference<Boolean>(booleanPreferencesKey("IsSentryAuthorized"), true)
+    data object IsMatomoAuthorized : DataStorePreference<Boolean>(booleanPreferencesKey("IsMatomoAuthorized"), true)
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/utils/DataStoreUtils.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/utils/DataStoreUtils.kt
@@ -27,14 +27,18 @@ import kotlinx.coroutines.runBlocking
 
 open class DataStorePreference<T>(val dataStoreKey: Preferences.Key<T>, val defaultValue: T)
 
-private fun <T> DataStore<Preferences>.flowOf(preference: DataStorePreference<T>): Flow<T> {
-    return data.map { it[preference.dataStoreKey] ?: preference.defaultValue }
+fun <T : Any> DataStore<Preferences>.getPreference(preference: DataStorePreference<T>): T {
+    return runBlocking { flowOf(preference).first() }
 }
 
-fun <T : Any> DataStore<Preferences>.getPreference(preference: DataStorePreference<T>): T = runBlocking { flowOf(preference).first() }
-
-operator fun <T : Any> Preferences.get(preference: DataStorePreference<T>): T = get(preference.dataStoreKey) ?: preference.defaultValue
+operator fun <T : Any> Preferences.get(preference: DataStorePreference<T>): T {
+    return get(preference.dataStoreKey) ?: preference.defaultValue
+}
 
 operator fun <T : Any> MutablePreferences.set(preference: DataStorePreference<T>, value: T) {
     set(preference.dataStoreKey, value)
+}
+
+private fun <T : Any> DataStore<Preferences>.flowOf(preference: DataStorePreference<T>): Flow<T> {
+    return data.map { it[preference] }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/utils/DataStoreUtils.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/utils/DataStoreUtils.kt
@@ -25,16 +25,16 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
 
-open class DataStoreValue<T>(val dataStoreKey: Preferences.Key<T>, val defaultValue: T)
+open class DataStorePreference<T>(val dataStoreKey: Preferences.Key<T>, val defaultValue: T)
 
-private fun <T> DataStore<Preferences>.flowOf(preference: DataStoreValue<T>): Flow<T> {
+private fun <T> DataStore<Preferences>.flowOf(preference: DataStorePreference<T>): Flow<T> {
     return data.map { it[preference.dataStoreKey] ?: preference.defaultValue }
 }
 
-fun <T : Any> DataStore<Preferences>.getValue(preference: DataStoreValue<T>): T = runBlocking { flowOf(preference).first() }
+fun <T : Any> DataStore<Preferences>.getPreference(preference: DataStorePreference<T>): T = runBlocking { flowOf(preference).first() }
 
-operator fun <T : Any> Preferences.get(preference: DataStoreValue<T>): T = get(preference.dataStoreKey) ?: preference.defaultValue
+operator fun <T : Any> Preferences.get(preference: DataStorePreference<T>): T = get(preference.dataStoreKey) ?: preference.defaultValue
 
-operator fun <T : Any> MutablePreferences.set(preference: DataStoreValue<T>, value: T) {
+operator fun <T : Any> MutablePreferences.set(preference: DataStorePreference<T>, value: T) {
     set(preference.dataStoreKey, value)
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/utils/DataStoreValue.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/utils/DataStoreValue.kt
@@ -1,0 +1,43 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.swisstransfer.ui.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+open class DataStoreValue<T>(val dataStoreKey: Preferences.Key<T>, val defaultValue: T)
+
+@Composable
+fun <T> DataStore<Preferences>.collectAsStateWithLifecycle(preference: DataStoreValue<T>, initialValue: T): State<T> {
+    return flowOf(preference).collectAsStateWithLifecycle(initialValue, LocalLifecycleOwner.current)
+}
+
+private fun <T> DataStore<Preferences>.flowOf(preference: DataStoreValue<T>): Flow<T> {
+    return data.map { it[preference.dataStoreKey] ?: preference.defaultValue }
+}
+
+suspend fun <T : Any> DataStore<Preferences>.setValue(preference: DataStoreValue<T>, value: T) {
+    edit { it[preference.dataStoreKey] = value }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/utils/DataStoreValue.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/utils/DataStoreValue.kt
@@ -25,7 +25,9 @@ import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
 
 open class DataStoreValue<T>(val dataStoreKey: Preferences.Key<T>, val defaultValue: T)
 
@@ -40,4 +42,8 @@ private fun <T> DataStore<Preferences>.flowOf(preference: DataStoreValue<T>): Fl
 
 suspend fun <T : Any> DataStore<Preferences>.setValue(preference: DataStoreValue<T>, value: T) {
     edit { it[preference.dataStoreKey] = value }
+}
+
+fun <T : Any> DataStore<Preferences>.getValue(preference: DataStoreValue<T>): T {
+    return runBlocking { flowOf(preference).first() }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ coilCompose = "3.0.2"
 composeAlpha = "1.8.0-alpha07"
 constraintlayoutCompose = "1.1.0"
 coreSplashscreen = "1.0.1"
+datastorePreferencesAndroid = "1.1.1"
 desugarJDK = "2.1.4"
 hiltAndroid = "2.53.1"
 hiltAndroidx = "1.2.0"
@@ -26,6 +27,7 @@ androidx-adaptive-layout = { module = "androidx.compose.material3.adaptive:adapt
 androidx-adaptive-navigation = { module = "androidx.compose.material3.adaptive:adaptive-navigation", version.ref = "adaptiveLayout" }
 androidx-constraintlayout-compose = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "constraintlayoutCompose" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplashscreen" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferencesAndroid" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ coilCompose = "3.0.2"
 composeAlpha = "1.8.0-alpha07"
 constraintlayoutCompose = "1.1.0"
 coreSplashscreen = "1.0.1"
-datastorePreferencesAndroid = "1.1.1"
+datastorePreferences = "1.1.1"
 desugarJDK = "2.1.4"
 hiltAndroid = "2.53.1"
 hiltAndroidx = "1.2.0"
@@ -27,7 +27,7 @@ androidx-adaptive-layout = { module = "androidx.compose.material3.adaptive:adapt
 androidx-adaptive-navigation = { module = "androidx.compose.material3.adaptive:adaptive-navigation", version.ref = "adaptiveLayout" }
 androidx-constraintlayout-compose = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "constraintlayoutCompose" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplashscreen" }
-androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferencesAndroid" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
 


### PR DESCRIPTION
I store the matomo/sentry opt out state in a data store and read that value to prevent sending matomo/sentry events if the user has opted out.

To do this while centralizing the definition of data store's entries I had to add a few helper methods.

I also removed `NetworkException`s from Sentry the same way we did it on mail.