### PR TITLE
fix: Avoid having the deeplinks piling in the stacks

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,7 +70,7 @@
         <activity
             android:name=".ui.LaunchActivity"
             android:exported="true"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:theme="@style/Theme.AppStarting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/LaunchActivity.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/LaunchActivity.kt
@@ -67,8 +67,14 @@ class LaunchActivity : ComponentActivity() {
     }.java
 
     private fun createDeeplink() {
-        val deepLinkIntent = Intent(Intent.ACTION_VIEW, intent.data, /*context*/this, MainActivity::class.java)
-        startActivity(deepLinkIntent)
+        Intent(
+            Intent.ACTION_VIEW,
+            intent.data,
+            /*context*/this,
+            MainActivity::class.java,
+        ).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }.also(::startActivity)
     }
 
     companion object {


### PR DESCRIPTION
Make the launchActivity SingleTask to fix a bug where opening the app with a deeplink prevent us from reopening this deeplink after
Also clear the stack so the deeplinks aren't piling up in the stacks