### PR TITLE
feat: Quick UI fixes

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/NewTransferFab.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/NewTransferFab.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.infomaniak.swisstransfer.ui.NewTransferActivity
 import com.infomaniak.swisstransfer.ui.theme.Margin
@@ -49,20 +48,13 @@ fun NewTransferFab(
     )
 }
 
-enum class NewTransferFabType(val fabType: FabType, private val defaultElevation: Dp?) {
+enum class NewTransferFabType(val fabType: FabType) {
 
-    BOTTOM_BAR(FabType.NORMAL, 0.dp),
-    EMPTY_STATE(FabType.BIG, 0.dp),
-    NAVIGATION_RAIL(FabType.NORMAL, 0.dp);
+    BOTTOM_BAR(FabType.NORMAL),
+    EMPTY_STATE(FabType.BIG);
 
     @Composable
-    fun elevation(): FloatingActionButtonElevation {
-        return if (defaultElevation != null) {
-            FloatingActionButtonDefaults.elevation(defaultElevation)
-        } else {
-            FloatingActionButtonDefaults.elevation()
-        }
-    }
+    fun elevation(): FloatingActionButtonElevation = FloatingActionButtonDefaults.elevation(0.dp)
 }
 
 @PreviewLightAndDark
@@ -74,8 +66,6 @@ private fun NewTransferFabPreview() {
                 NewTransferFab(newTransferFabType = NewTransferFabType.BOTTOM_BAR)
                 Spacer(Modifier.width(Margin.Large))
                 NewTransferFab(newTransferFabType = NewTransferFabType.EMPTY_STATE)
-                Spacer(Modifier.width(Margin.Large))
-                NewTransferFab(newTransferFabType = NewTransferFabType.NAVIGATION_RAIL)
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/NewTransferFab.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/NewTransferFab.kt
@@ -51,8 +51,8 @@ fun NewTransferFab(
 
 enum class NewTransferFabType(val fabType: FabType, private val defaultElevation: Dp?) {
 
-    BOTTOM_BAR(FabType.NORMAL, null),
-    EMPTY_STATE(FabType.BIG, null),
+    BOTTOM_BAR(FabType.NORMAL, 0.dp),
+    EMPTY_STATE(FabType.BIG, 0.dp),
     NAVIGATION_RAIL(FabType.NORMAL, 0.dp);
 
     @Composable

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferTextField.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwissTransferTextField.kt
@@ -30,7 +30,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -86,7 +85,7 @@ fun SwissTransferTextField(
         minLines = minLineNumber,
         maxLines = maxLineNumber,
         colors = SwissTransferTextFieldDefaults.colors(),
-        textStyle = TextStyle(color = SwissTransferTheme.colors.primaryTextColor),
+        textStyle = LocalTextStyle.current.copy(color = SwissTransferTheme.colors.primaryTextColor),
         onValueChange = {
             text = it
             onValueChange?.invoke(it)


### PR DESCRIPTION
After discussing with the designer, he gave a few quick first feedbacks:

* The fabs should always have 0 elevation (received screen empty state or bottom right of the screen)
    * Take this opportunity to remove the now useless HAND_RAIL value
* The textfields label and text should have the same font size. Right now, the label was at 16sp and the text was at 14sp. For now, he chose to use the native, default 16sp size of text and will check if other texts on the screen need to change later on
