### PR TITLE
fix: Correctly manage the app tasks when backing depending on isTaskRoot

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/LaunchActivity.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/LaunchActivity.kt
@@ -80,7 +80,7 @@ class LaunchActivity : ComponentActivity() {
     private fun createNewTransferSharingFileIntent(): Intent {
         return Intent(intent).apply {
             setClass(this@LaunchActivity, NewTransferActivity::class.java)
-            setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/NewTransferActivity.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/NewTransferActivity.kt
@@ -25,8 +25,8 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.core.os.BundleCompat
 import androidx.lifecycle.lifecycleScope
-import com.infomaniak.swisstransfer.ui.screen.newtransfer.NewTransferScreen
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.NewTransferOpenManager
+import com.infomaniak.swisstransfer.ui.screen.newtransfer.NewTransferScreen
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -45,9 +45,13 @@ class NewTransferActivity : ComponentActivity() {
         handleSharedFiles()
         setContent {
             SwissTransferTheme {
-                NewTransferScreen(closeActivity = { finish() })
+                NewTransferScreen(closeActivity = { finishAppAndRemoveTaskIfNeeded() })
             }
         }
+    }
+
+    private fun finishAppAndRemoveTaskIfNeeded() {
+        if (isTaskRoot) finishAndRemoveTask() else finish()
     }
 
     private fun handleSharedFiles() {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
@@ -144,7 +144,7 @@ class ImportFilesViewModel @Inject constructor(
                 importFilesViewModelStartup.restoreAlreadyImportedFiles()
             }
 
-            importFilesViewModelStartup.handleOpenReasonAsync()
+            importFilesViewModelStartup.handleOpenReasonAsync(isFirstViewModelCreation)
 
             launch { importFilesViewModelStartup.continuouslyCopyPickedFilesToLocalStorage() }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModelStartup.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModelStartup.kt
@@ -37,7 +37,7 @@ class ImportFilesViewModelStartup @Inject constructor(
         importationFilesManager.restoreAlreadyImportedFiles()
     }
 
-    suspend fun handleOpenReasonAsync() {
+    suspend fun handleOpenReasonAsync(isFirstViewModelCreation: Boolean) {
         coroutineScope {
             launch {
                 when (val reason = newTransferOpenManager.readOpenReason()) {
@@ -45,7 +45,7 @@ class ImportFilesViewModelStartup @Inject constructor(
                         importationFilesManager.importFiles(reason.uris)
                     }
                     NewTransferOpenManager.Reason.Other -> {
-                        _openFilePickerEvent.send(Unit)
+                        if (isFirstViewModelCreation) _openFilePickerEvent.send(Unit)
                     }
                 }
             }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModelStartup.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModelStartup.kt
@@ -1,0 +1,63 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.swisstransfer.ui.screen.newtransfer
+
+import com.infomaniak.multiplatform_swisstransfer.managers.UploadManager
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class ImportFilesViewModelStartup @Inject constructor(
+    private val importationFilesManager: ImportationFilesManager,
+    private val newTransferOpenManager: NewTransferOpenManager,
+    private val uploadManager: UploadManager,
+) {
+    private val _openFilePickerEvent: Channel<Unit> = Channel(capacity = CONFLATED)
+    val openFilePickerEvent: ReceiveChannel<Unit> = _openFilePickerEvent
+
+    suspend fun restoreAlreadyImportedFiles() {
+        importationFilesManager.restoreAlreadyImportedFiles()
+    }
+
+    suspend fun handleOpenReasonAsync() {
+        coroutineScope {
+            launch {
+                when (val reason = newTransferOpenManager.readOpenReason()) {
+                    is NewTransferOpenManager.Reason.ExternalShareIncoming -> {
+                        importationFilesManager.importFiles(reason.uris)
+                    }
+                    NewTransferOpenManager.Reason.Other -> {
+                        _openFilePickerEvent.send(Unit)
+                    }
+                }
+            }
+        }
+    }
+
+    suspend fun continuouslyCopyPickedFilesToLocalStorage() {
+        importationFilesManager.continuouslyCopyPickedFilesToLocalStorage()
+    }
+
+    suspend fun removeOldData() {
+        importationFilesManager.removeLocalCopyFolder()
+        uploadManager.removeAllUploadSession()
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferScreen.kt
@@ -17,6 +17,7 @@
  */
 package com.infomaniak.swisstransfer.ui.screen.newtransfer
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -35,6 +36,10 @@ import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
 fun NewTransferScreen(closeActivity: () -> Unit) {
     val navController = rememberNavController()
     var displayConfirmationDialog by rememberSaveable { mutableStateOf(false) }
+
+    BackHandler(!displayConfirmationDialog) {
+        closeActivity()
+    }
 
     NewTransferNavHost(
         navController,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferScreen.kt
@@ -37,9 +37,7 @@ fun NewTransferScreen(closeActivity: () -> Unit) {
     val navController = rememberNavController()
     var displayConfirmationDialog by rememberSaveable { mutableStateOf(false) }
 
-    BackHandler(!displayConfirmationDialog) {
-        closeActivity()
-    }
+    BackHandler(!displayConfirmationDialog) { closeActivity() }
 
     NewTransferNavHost(
         navController,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -17,6 +17,7 @@
  */
 package com.infomaniak.swisstransfer.ui.screen.newtransfer.importfiles
 
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
@@ -90,6 +91,8 @@ fun ImportFilesScreen(
     val snackbarHostState = remember { SnackbarHostState() }
 
     val emailTextFieldCallbacks = importFilesViewModel.getEmailTextFieldCallbacks()
+
+    BackHandler { closeActivity() }
 
     HandleStartupFilePick(importFilesViewModel.openFilePickerEvent, ::pickFiles)
 


### PR DESCRIPTION
The app task was empty but still there when sharing a file to the app when the app was never launched before