### PR TITLE
fix: Use coherent ordering of files when importing files

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/filesdetails/NewTransferFilesDetailsScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/filesdetails/NewTransferFilesDetailsScreen.kt
@@ -49,7 +49,7 @@ fun NewTransferFilesDetailsScreen(
     }
 
     NewTransferFilesDetailsScreen(
-        files = (uiState as? FilesDetailsUiState.Success)?.files ?: emptyList(),
+        files = (uiState as? FilesDetailsUiState.Success)?.files?.asReversed() ?: emptyList(),
         withFilesSize = withFilesSize,
         withSpaceLeft = withSpaceLeft,
         onFileRemoved = getOnFileRemoveCallback(importFilesViewModel, withFileDelete),


### PR DESCRIPTION
The ImportedFilesCard shows the latest files first but the TransferDetailsScreen was showing the earliest files first. This modifies the ordering of the data passed to the TransferDetailsScreen in order to match the "latest files first" logic of the ImportedFilesCard