### PR TITLE
fix: Set isFirstViewModelCreation to true

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
@@ -152,7 +152,7 @@ class ImportFilesViewModel @Inject constructor(
             val wasFirstViewModelCreation = isFirstViewModelCreation
             launch { handleOpenReason(wasFirstViewModelCreation) }
 
-            importationFilesManager.continuouslyCopyPickedFilesToLocalStorage()
+            launch { importationFilesManager.continuouslyCopyPickedFilesToLocalStorage() }
 
             isFirstViewModelCreation = false
         }


### PR DESCRIPTION
Right now the isFirstViewModelCreation is never set to true because the code above it suspends forever and we can never reach the line that set isFirstViewModelCreation to true. This modification makes the suspend code async in order to reach the place where isFirstViewModelCreation is set to true