### PR TITLE
fix: Handle NewTransferActivity task correctly with the sharing of files

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -110,7 +110,7 @@
 
         <activity
             android:name=".ui.NewTransferActivity"
-            android:launchMode="singleTask" />
+            android:launchMode="standard" />
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -108,9 +108,9 @@
             android:name=".ui.MainActivity"
             android:launchMode="singleTask" />
 
-        <activity
-            android:name=".ui.NewTransferActivity"
-            android:launchMode="standard" />
+        <!-- NewMessageActivity needs its standard launch mode in order for Intent.FLAG_ACTIVITY_CLEAR_TOP to clear and recreate
+        the NewTransferActivity -->
+        <activity android:name=".ui.NewTransferActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -108,8 +108,8 @@
             android:name=".ui.MainActivity"
             android:launchMode="singleTask" />
 
-        <!-- NewMessageActivity needs its standard launch mode in order for Intent.FLAG_ACTIVITY_CLEAR_TOP to clear and recreate
-        the NewTransferActivity -->
+        <!-- We need NewMessageActivity to have its standard launchMode in the Manifest
+            in order for FLAG_ACTIVITY_CLEAR_TOP to kill and recreate NewMessageActivity -->
         <activity android:name=".ui.NewTransferActivity" />
     </application>
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/LaunchActivity.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/LaunchActivity.kt
@@ -80,8 +80,8 @@ class LaunchActivity : ComponentActivity() {
     private fun createNewTransferSharingFileIntent(): Intent {
         return Intent(intent).apply {
             setClass(this@LaunchActivity, NewTransferActivity::class.java)
-            // We need NewMessageActivity to have its standard launchMode in manifest in order for clear top to kill and recreate
-            // NewMessageActivity
+            // We need NewMessageActivity to have its standard launchMode in the Manifest
+            // in order for FLAG_ACTIVITY_CLEAR_TOP to kill and recreate NewMessageActivity
             setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         }
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/LaunchActivity.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/LaunchActivity.kt
@@ -80,7 +80,7 @@ class LaunchActivity : ComponentActivity() {
     private fun createNewTransferSharingFileIntent(): Intent {
         return Intent(intent).apply {
             setClass(this@LaunchActivity, NewTransferActivity::class.java)
-            setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/LaunchActivity.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/LaunchActivity.kt
@@ -80,6 +80,8 @@ class LaunchActivity : ComponentActivity() {
     private fun createNewTransferSharingFileIntent(): Intent {
         return Intent(intent).apply {
             setClass(this@LaunchActivity, NewTransferActivity::class.java)
+            // We need NewMessageActivity to have its standard launchMode in manifest in order for clear top to kill and recreate
+            // NewMessageActivity
             setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         }
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/NewTransferActivity.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/NewTransferActivity.kt
@@ -54,7 +54,7 @@ class NewTransferActivity : ComponentActivity() {
                     startDestination = getStartDestination(),
                     closeActivity = {
                         startActivity(Intent(this, MainActivity::class.java))
-                        finish()
+                        finishAppAndRemoveTaskIfNeeded()
                     },
                 )
             }
@@ -82,6 +82,10 @@ class NewTransferActivity : ComponentActivity() {
         val uris = BundleCompat.getParcelableArrayList(extras, Intent.EXTRA_STREAM, Uri::class.java)
 
         return uris ?: emptyList()
+    }
+
+    private fun finishAppAndRemoveTaskIfNeeded() {
+        if (isTaskRoot) finishAndRemoveTask() else finish()
     }
 
     private fun getStartDestination(): NewTransferNavigation {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/NewTransferActivity.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/NewTransferActivity.kt
@@ -52,10 +52,7 @@ class NewTransferActivity : ComponentActivity() {
             SwissTransferTheme {
                 NewTransferScreen(
                     startDestination = getStartDestination(),
-                    closeActivity = {
-                        startActivity(Intent(this, MainActivity::class.java))
-                        finishAppAndRemoveTaskIfNeeded()
-                    },
+                    closeActivity = { startMainActivityIfTaskIsEmpty -> finishNewTransferActivity(startMainActivityIfTaskIsEmpty) },
                 )
             }
         }
@@ -84,8 +81,15 @@ class NewTransferActivity : ComponentActivity() {
         return uris ?: emptyList()
     }
 
-    private fun finishAppAndRemoveTaskIfNeeded() {
-        if (isTaskRoot) finishAndRemoveTask() else finish()
+    private fun finishNewTransferActivity(startMainActivityIfTaskIsEmpty: Boolean) {
+        when {
+            isTaskRoot && startMainActivityIfTaskIsEmpty -> {
+                finish()
+                startActivity(Intent(this, MainActivity::class.java))
+            }
+            isTaskRoot -> finishAndRemoveTask()
+            else -> finish()
+        }
     }
 
     private fun getStartDestination(): NewTransferNavigation {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/NewTransferActivity.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/NewTransferActivity.kt
@@ -52,7 +52,9 @@ class NewTransferActivity : ComponentActivity() {
             SwissTransferTheme {
                 NewTransferScreen(
                     startDestination = getStartDestination(),
-                    closeActivity = { startMainActivityIfTaskIsEmpty -> finishNewTransferActivity(startMainActivityIfTaskIsEmpty) },
+                    closeActivity = { startMainActivityIfTaskIsEmpty ->
+                        finishNewTransferActivity(startMainActivityIfTaskIsEmpty)
+                    },
                 )
             }
         }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/NewTransferActivity.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/NewTransferActivity.kt
@@ -86,8 +86,8 @@ class NewTransferActivity : ComponentActivity() {
     private fun finishNewTransferActivity(startMainActivityIfTaskIsEmpty: Boolean) {
         when {
             isTaskRoot && startMainActivityIfTaskIsEmpty -> {
-                finish()
                 startActivity(Intent(this, MainActivity::class.java))
+                finish()
             }
             isTaskRoot -> finishAndRemoveTask()
             else -> finish()

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferNavHost.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferNavHost.kt
@@ -41,7 +41,7 @@ import io.sentry.SentryLevel
 fun NewTransferNavHost(
     navController: NavHostController,
     startDestination: NewTransferNavigation,
-    closeActivity: () -> Unit,
+    closeActivity: (startMainActivityIfTaskIsEmpty: Boolean) -> Unit,
     closeActivityAndPromptForValidation: () -> Unit,
     cancelFailureNotification: () -> Unit,
 ) {
@@ -53,7 +53,7 @@ fun NewTransferNavHost(
             cancelFailureNotification()
             ImportFilesScreen(
                 importFilesViewModel = hiltViewModel<ImportFilesViewModel>(it),
-                closeActivity = closeActivity,
+                closeActivity = { closeActivity(false) },
                 navigateToUploadProgress = { transferType, totalSize ->
                     navController.navigate(UploadProgressDestination(transferType, totalSize))
                 },
@@ -81,7 +81,7 @@ fun NewTransferNavHost(
                 },
                 navigateToUploadError = { navController.navigate(UploadErrorDestination(args.transferType, args.totalSize)) },
                 navigateBackToImportFiles = { navController.popBackStack(route = ImportFilesDestination, inclusive = false) },
-                closeActivity = closeActivity,
+                closeActivity = { closeActivity(false) },
             )
         }
         composable<UploadSuccessDestination> {
@@ -90,7 +90,7 @@ fun NewTransferNavHost(
                 transferType = args.transferType,
                 transferUuid = args.transferUuid,
                 transferUrl = args.transferUrl,
-                closeActivity = closeActivity,
+                closeActivity = { closeActivity(true) },
             )
         }
         composable<UploadErrorDestination> {
@@ -114,7 +114,7 @@ fun NewTransferNavHost(
                     }
                 },
                 navigateBackToImportFiles = { navController.popBackStack(route = ImportFilesDestination, inclusive = false) },
-                closeActivity = closeActivity,
+                closeActivity = { closeActivity(false) },
             )
         }
         composable<NewTransferFilesDetailsDestination> {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferNavHost.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferNavHost.kt
@@ -114,7 +114,7 @@ fun NewTransferNavHost(
                     }
                 },
                 navigateBackToImportFiles = { navController.popBackStack(route = ImportFilesDestination, inclusive = false) },
-                closeActivity = { closeActivity(false) },
+                closeActivity = { closeActivity(true) },
             )
         }
         composable<NewTransferFilesDetailsDestination> {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferNavHost.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferNavHost.kt
@@ -81,6 +81,7 @@ fun NewTransferNavHost(
                 },
                 navigateToUploadError = { navController.navigate(UploadErrorDestination(args.transferType, args.totalSize)) },
                 navigateBackToImportFiles = { navController.popBackStack(route = ImportFilesDestination, inclusive = false) },
+                // Called instead of `navigateBackToImportFiles()` when the app has been killed while uploading
                 closeActivity = { closeActivity(false) },
             )
         }
@@ -114,6 +115,7 @@ fun NewTransferNavHost(
                     }
                 },
                 navigateBackToImportFiles = { navController.popBackStack(route = ImportFilesDestination, inclusive = false) },
+                // Called instead of `navigateBackToImportFiles()` when the app has been killed while uploading
                 closeActivity = { closeActivity(true) },
             )
         }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferScreen.kt
@@ -36,7 +36,7 @@ import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
 @Composable
 fun NewTransferScreen(
     startDestination: NewTransferNavigation,
-    closeActivity: () -> Unit,
+    closeActivity: (startMainActivityIfTaskIsEmpty: Boolean) -> Unit,
     newTransferViewModel: NewTransferViewModel = hiltViewModel<NewTransferViewModel>(),
 ) {
 
@@ -51,7 +51,12 @@ fun NewTransferScreen(
         cancelFailureNotification = { newTransferViewModel.cancelFailureNotification() }
     )
 
-    if (displayConfirmationDialog) ConfirmLeavingDialog(onLeave = closeActivity, onCancel = { displayConfirmationDialog = false })
+    if (displayConfirmationDialog) {
+        ConfirmLeavingDialog(
+            onLeave = { closeActivity(false) },
+            onCancel = { displayConfirmationDialog = false },
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -17,6 +17,7 @@
  */
 package com.infomaniak.swisstransfer.ui.screen.newtransfer.importfiles
 
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
@@ -104,6 +105,8 @@ fun ImportFilesScreen(
     val snackbarHostState = remember { SnackbarHostState() }
 
     val emailTextFieldCallbacks = importFilesViewModel.getEmailTextFieldCallbacks()
+
+    BackHandler { closeActivity() }
 
     HandleStartupFilePick(importFilesViewModel.openFilePickerEvent, ::pickFiles)
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadErrorScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadErrorScreen.kt
@@ -62,7 +62,7 @@ fun UploadErrorScreen(
                 LargeButton(
                     modifier = it,
                     title = stringResource(R.string.buttonCancelTransfer),
-                    style = ButtonType.Destructive,
+                    style = ButtonType.DestructiveText,
                     onClick = { uploadProgressViewModel.removeAllUploadSession(onCompletion = closeActivity) },
                 )
             }

--- a/app/src/main/java/com/infomaniak/swisstransfer/workers/UploadWorker.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/workers/UploadWorker.kt
@@ -180,6 +180,7 @@ class UploadWorker @AssistedInject constructor(
 
     private fun createProgressNotificationIntent(totalSize: Long): Intent {
         return Intent(applicationContext, NewTransferActivity::class.java)
+            .setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
             .putExtra(NOTIFICATION_NAVIGATION_KEY, NotificationNavigation.UploadProgress.name)
             .putExtra(TRANSFER_TYPE_KEY, transferType.name)
             .putExtra(TRANSFER_TOTAL_SIZE_KEY, totalSize)
@@ -197,6 +198,7 @@ class UploadWorker @AssistedInject constructor(
         notificationsUtils.sendUploadNotification(
             notificationId = NOTIFICATION_ID,
             intent = Intent(applicationContext, NewTransferActivity::class.java)
+                .setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
                 .putExtra(NOTIFICATION_NAVIGATION_KEY, NotificationNavigation.UploadSuccess.name)
                 .putExtra(TRANSFER_TYPE_KEY, transferType.name)
                 .putExtra(TRANSFER_UUID_KEY, transferUuid)
@@ -210,6 +212,7 @@ class UploadWorker @AssistedInject constructor(
         notificationsUtils.sendUploadNotification(
             notificationId = NOTIFICATION_ID,
             intent = Intent(applicationContext, NewTransferActivity::class.java)
+                .setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
                 .putExtra(NOTIFICATION_NAVIGATION_KEY, NotificationNavigation.UploadFailure.name)
                 .putExtra(TRANSFER_TYPE_KEY, transferType.name)
                 .putExtra(TRANSFER_TOTAL_SIZE_KEY, totalSize),


### PR DESCRIPTION
Clear task when NewTransferActivity is the root of the task and make sure that the NewTransferActivity can't be stacked multiple times if files are shared to it