### PR TITLE
feat: Email text field auto add email when leaving field

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/components/EmailAddressTextField.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/components/EmailAddressTextField.kt
@@ -58,9 +58,9 @@ fun EmailAddressTextField(
 ) {
 
     val state = remember(validatedRecipientsEmails) {
-        EmailAddressTextFieldState(validatedRecipientsEmails, initialText = initialValue)
+        EmailAddressTextFieldState(initialValue, validatedRecipientsEmails, onValueChange)
     }
-    var textFieldValue by state::textFieldValue
+    val textFieldValue by state::textFieldValue
     val interactionSource = remember { MutableInteractionSource() }
 
     val cursorColor by animateColorAsState(
@@ -68,21 +68,7 @@ fun EmailAddressTextField(
         label = "CursorColor",
     )
 
-    fun updateUiTextValue(newValue: TextFieldValue) {
-        state.unselectChip()
-        textFieldValue = newValue
-        onValueChange(newValue)
-    }
-
-    val keyboardActions = KeyboardActions(
-        onDone = {
-            val trimmedText = textFieldValue.text.trim()
-            if (trimmedText.isValidEmail()) {
-                validatedRecipientsEmails.set(validatedRecipientsEmails.get() + trimmedText)
-                updateUiTextValue(TextFieldValue())
-            }
-        },
-    )
+    val keyboardActions = KeyboardActions(onDone = { state.addRecipientAddress() })
 
     val keyboardOptions = KeyboardOptions(
         keyboardType = KeyboardType.Email,
@@ -93,12 +79,17 @@ fun EmailAddressTextField(
     val emailAddressTextFieldModifier = modifier
         .fillMaxWidth()
         .onPreviewKeyEvent(state::onKeyEvent)
-        .onFocusChanged { event -> if (!event.isFocused) state.unselectChip() }
+        .onFocusChanged { event ->
+            if (!event.isFocused) {
+                state.unselectChip()
+                state.addRecipientAddress()
+            }
+        }
 
     BasicTextField(
         modifier = emailAddressTextFieldModifier,
         value = textFieldValue,
-        onValueChange = ::updateUiTextValue,
+        onValueChange = state::updateUiTextValue,
         textStyle = TextStyle(color = SwissTransferTheme.colors.primaryTextColor),
         keyboardOptions = keyboardOptions,
         keyboardActions = keyboardActions,
@@ -122,8 +113,9 @@ fun EmailAddressTextField(
 }
 
 private class EmailAddressTextFieldState(
-    private val validatedEmails: GetSetCallbacks<Set<String>>,
-    initialText: String
+    initialText: String,
+    private val validatedRecipientsEmails: GetSetCallbacks<Set<String>>,
+    private val onValueChange: (TextFieldValue) -> Unit
 ) {
     var textFieldValue by mutableStateOf(TextFieldValue(initialText))
 
@@ -134,7 +126,22 @@ private class EmailAddressTextFieldState(
         selectedChipIndex = UNSELECTED_CHIP_INDEX
     }
 
-    fun onKeyEvent(event: KeyEvent): Boolean = when {
+
+    fun updateUiTextValue(newValue: TextFieldValue) {
+        unselectChip()
+        textFieldValue = newValue
+        onValueChange(newValue)
+    }
+
+    fun addRecipientAddress() {
+        val trimmedText = textFieldValue.text.trim()
+        if (trimmedText.isValidEmail()) {
+            validatedRecipientsEmails.set(validatedRecipientsEmails.get() + trimmedText)
+            updateUiTextValue(TextFieldValue())
+        }
+    }
+
+    fun onKeyEvent(event: KeyEvent) = when {
         event.type != KeyEventType.KeyDown -> false
         event.key == Key.Backspace -> handleBackspace()
         event.isNavigatingLeft() -> handlePreviousNavigation()
@@ -164,14 +171,14 @@ private class EmailAddressTextFieldState(
         false
     } else {
         // If any chip is already selected, pressing on backspace deletes it and reset the selection
-        validatedEmails.get().elementAtOrNull(selectedChipIndex)?.let { email ->
-            validatedEmails.set(validatedEmails.get().minusElement(email))
+        validatedRecipientsEmails.get().elementAtOrNull(selectedChipIndex)?.let { email ->
+            validatedRecipientsEmails.set(validatedRecipientsEmails.get().minusElement(email))
         }
         unselectChip()
         true
     }
 
-    private fun getLastEmailIndex() = validatedEmails.get().toList().lastIndex
+    private fun getLastEmailIndex() = validatedRecipientsEmails.get().toList().lastIndex
 
     private fun handlePreviousNavigation(): Boolean = when {
         selectedChipIndex == UNSELECTED_CHIP_INDEX && textFieldValue.selection.start == 0 -> {
@@ -201,7 +208,7 @@ private fun EmailAddressDecorationBox(
     label: String,
     interactionSource: MutableInteractionSource,
     isError: Boolean,
-    supportingText: @Composable() (() -> Unit)?,
+    supportingText: @Composable (() -> Unit)?,
     textFieldColors: TextFieldColors,
 ) {
     OutlinedTextFieldDefaults.DecorationBox(

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/components/EmailAddressTextField.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/components/EmailAddressTextField.kt
@@ -46,6 +46,7 @@ import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.GetSetCallbacks
 import com.infomaniak.swisstransfer.ui.utils.PreviewLightAndDark
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun EmailAddressTextField(
     modifier: Modifier = Modifier,
@@ -67,6 +68,9 @@ fun EmailAddressTextField(
         targetValue = if (isError) SwissTransferTheme.materialColors.error else SwissTransferTheme.materialColors.primary,
         label = "CursorColor",
     )
+
+    val isImeVisible = WindowInsets.isImeVisible
+    LaunchedEffect(isImeVisible) { if (!isImeVisible) state.addRecipientAddress() }
 
     val keyboardActions = KeyboardActions(onDone = { state.addRecipientAddress() })
 


### PR DESCRIPTION
When the EmailTextField loses focus, or the user close the keyboard, we automatically check the field's value to add the email to the list