### PR TITLE
feat: Animate transfers in transfer lists

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwipeToDismissComponent.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/SwipeToDismissComponent.kt
@@ -55,6 +55,7 @@ private const val SWIPED_ELEVATION = 4
 
 @Composable
 fun SwipeToDismissComponent(
+    modifier: Modifier = Modifier,
     contentShape: Shape,
     onSwiped: () -> Unit = {},
     content: @Composable () -> Unit,
@@ -84,6 +85,7 @@ fun SwipeToDismissComponent(
     )
 
     SwipeToDismissBox(
+        modifier = modifier,
         state = state,
         enableDismissFromStartToEnd = false,
         backgroundContent = {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransferItemList.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransferItemList.kt
@@ -17,6 +17,9 @@
  */
 package com.infomaniak.swisstransfer.ui.components.transfer
 
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -44,6 +47,7 @@ import com.infomaniak.swisstransfer.ui.utils.PreviewLightAndDark
 
 @Composable
 fun TransferItemList(
+    modifier: Modifier = Modifier,
     direction: TransferDirection,
     getSelectedTransferUuid: () -> String?,
     getTransfers: () -> GroupedTransfers,
@@ -60,6 +64,7 @@ fun TransferItemList(
     }
 
     LazyColumn(
+        modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(Margin.Mini),
         contentPadding = contentPadding,
     ) {
@@ -72,6 +77,7 @@ fun TransferItemList(
                     modifier = Modifier
                         .fillParentMaxWidth()
                         .background(SwissTransferTheme.materialColors.background)
+                        .animateItem()
                 ) {
                     Text(
                         section.title(LocalContext.current),
@@ -89,6 +95,7 @@ fun TransferItemList(
                 itemContent = {
                     val transfer = transfers[it]
                     SwipeToDismissComponent(
+                        modifier = Modifier.animateItem(),
                         contentShape = itemShape,
                         onSwiped = { onSwiped(transfer.uuid) },
                     ) {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransfersListWithExpiredBottomSheet.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransfersListWithExpiredBottomSheet.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.infomaniak.multiplatform_swisstransfer.common.interfaces.ui.TransferUi
 import com.infomaniak.multiplatform_swisstransfer.common.models.TransferDirection
@@ -36,6 +37,7 @@ import com.infomaniak.swisstransfer.ui.utils.isExpired
 
 @Composable
 fun TransfersListWithExpiredBottomSheet(
+    modifier: Modifier = Modifier,
     direction: TransferDirection,
     navigateToDetails: (transferUuid: String) -> Unit,
     getSelectedTransferUuid: () -> String?,
@@ -46,6 +48,7 @@ fun TransfersListWithExpiredBottomSheet(
     var expiredTransfer: TransferUi? by rememberSaveable { mutableStateOf(null) }
 
     TransferItemList(
+        modifier = modifier,
         direction = direction,
         getSelectedTransferUuid = getSelectedTransferUuid,
         getTransfers = getTransfers,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/received/ReceivedScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/received/ReceivedScreen.kt
@@ -18,10 +18,13 @@
 package com.infomaniak.swisstransfer.ui.screen.main.received
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.infomaniak.multiplatform_swisstransfer.common.models.TransferDirection
@@ -32,6 +35,7 @@ import com.infomaniak.swisstransfer.ui.components.SwissTransferTopAppBar
 import com.infomaniak.swisstransfer.ui.components.transfer.TransfersListWithExpiredBottomSheet
 import com.infomaniak.swisstransfer.ui.images.AppImages.AppIllus
 import com.infomaniak.swisstransfer.ui.images.illus.MascotWithMagnifyingGlass
+import com.infomaniak.swisstransfer.ui.previewparameter.GroupedTransfersPreviewParameterProvider
 import com.infomaniak.swisstransfer.ui.screen.main.components.SwissTransferScaffold
 import com.infomaniak.swisstransfer.ui.screen.main.received.components.ReceivedEmptyFab
 import com.infomaniak.swisstransfer.ui.screen.main.transfers.GroupedTransfers
@@ -116,6 +120,7 @@ private fun ReceivedContent(
         )
     } else {
         TransfersListWithExpiredBottomSheet(
+            modifier = Modifier.fillMaxHeight(),
             direction = TransferDirection.RECEIVED,
             navigateToDetails = navigateToDetails,
             getSelectedTransferUuid = getSelectedTransferUuid,
@@ -127,11 +132,11 @@ private fun ReceivedContent(
 
 @PreviewAllWindows
 @Composable
-private fun Preview() {
+private fun Preview(@PreviewParameter(GroupedTransfersPreviewParameterProvider::class) transfers: GroupedTransfers) {
     SwissTransferTheme {
         Surface {
             ReceivedScreen(
-                uiState = { TransferUiState.Success(emptyMap()) },
+                uiState = { TransferUiState.Success(transfers) },
                 isFirstTransfer = { true },
                 navigateToDetails = {},
                 getSelectedTransferUuid = { null },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/sent/SentScreen.kt
@@ -17,9 +17,11 @@
  */
 package com.infomaniak.swisstransfer.ui.screen.main.sent
 
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -114,6 +116,7 @@ private fun SentContent(
         SentEmptyScreen()
     } else {
         TransfersListWithExpiredBottomSheet(
+            modifier = Modifier.fillMaxHeight(),
             direction = TransferDirection.SENT,
             navigateToDetails = navigateToDetails,
             getSelectedTransferUuid = getSelectedTransferUuid,


### PR DESCRIPTION
When adding or removing items from the list of transfers it was instantaneous and was not animated. This PR adds animations when a new transfer is added or swiped away from the list