### PR TITLE
feat: Let the user leave if we can't cancel the upload successfully

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
@@ -75,7 +75,7 @@ fun UploadProgressScreen(
         totalSizeInBytes = totalSizeInBytes,
         showBottomSheet = GetSetCallbacks(get = { showBottomSheet }, set = { showBottomSheet = it }),
         adScreenType = adScreenType,
-        onCancel = { uploadProgressViewModel.cancelUpload() }
+        onCancel = { uploadProgressViewModel.cancelUpload(onFailedCancellation = closeActivity) }
     )
 }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressViewModel.kt
@@ -79,7 +79,7 @@ class UploadProgressViewModel @Inject constructor(
         }
     }
 
-    fun cancelUpload() {
+    fun cancelUpload(onFailedCancellation: () -> Unit) {
         uploadWorkerScheduler.cancelWork()
 
         viewModelScope.launch(ioDispatcher) {
@@ -92,6 +92,7 @@ class UploadProgressViewModel @Inject constructor(
                 }
             }.onFailure { exception ->
                 SentryLog.e(TAG, "Failure on cancel upload", exception)
+                onFailedCancellation()
             }
         }
     }


### PR DESCRIPTION
This only occurs if something very unexpected happens, but at least we should let the user leave even if we failed canceling the upload in progress properly.

When the app integrity check will be placed on the upload progress screen, this will also happen when we haven't received a container id from the API yet. If we want to cancel the upload during the API integrity this will also occur