### PR TITLE
fix: Fix double click leading to empty white screen

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferNavHost.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferNavHost.kt
@@ -65,7 +65,7 @@ fun NewTransferNavHost(
             val args = it.toRoute<ValidateUserEmailDestination>()
             ValidateUserEmailScreen(
                 closeActivity = closeActivityAndPromptForValidation,
-                navigateBack = { navController.popBackStack() },
+                navigateBack = { navController.navigateUp() },
                 navigateToUploadInProgress = { totalSize ->
                     navController.navigate(UploadProgressDestination(TransferTypeUi.Mail, totalSize))
                 },
@@ -127,7 +127,7 @@ fun NewTransferNavHost(
                 withFilesSize = true,
                 withSpaceLeft = true,
                 withFileDelete = true,
-                navigateBack = { navController.popBackStack() },
+                navigateBack = { navController.navigateUp() },
             )
         }
     }


### PR DESCRIPTION
Clicking on the back arrow of the files details screen while the screen is animated as the screen leave the composition lets us back twice in a row. Doing so brings us to some strange empty white screen.

By calling navigateUp instead, the issue is no more