### PR TITLE
fix: Missing AppSettings in NewTransferActivity when sharing files to the app before user login

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/LaunchActivity.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/LaunchActivity.kt
@@ -55,15 +55,27 @@ class LaunchActivity : ComponentActivity() {
     private suspend fun startTargetActivity() {
         val intent = when {
             hasValidTransferDeeplink() -> {
-                if (!accountUtils.isUserConnected()) accountUtils.login()
+                connectLoggedOutUser()
                 createDeeplinkIntent()
             }
-            isSharingFilesToTheApp() -> createNewTransferSharingFileIntent()
+            isSharingFilesToTheApp() -> {
+                connectLoggedOutUser()
+                createNewTransferSharingFileIntent()
+            }
             accountUtils.isUserConnected() -> Intent(this, MainActivity::class.java)
             else -> Intent(this, OnboardingActivity::class.java)
         }
 
         startActivity(intent)
+    }
+
+
+    /**
+     * A user will be logged out if the app received an intent before the user ever finished the onboarding. In case of such an
+     * intent, we want to handle it correctly but we first need to connect the user seamlessly.
+     */
+    private suspend fun connectLoggedOutUser() {
+        if (!accountUtils.isUserConnected()) accountUtils.login()
     }
 
     private fun createDeeplinkIntent(): Intent {


### PR DESCRIPTION
If the user is logged out and shares files to the app, we won't find any AppSettings in Realm because they're initialized to an empty value during the login step.

A user will be logged out if the app received an intent before the user ever finished the onboarding. In case of such intent, we want to handle it correctly but we first need to connect the user seamlessly to avoid badly configured app settings