### PR TITLE
fix: Fix transfer change not taken into account

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/TransferDetailsScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/TransferDetailsScreen.kt
@@ -71,6 +71,7 @@ import com.infomaniak.swisstransfer.ui.utils.openFile
 import com.infomaniak.swisstransfer.ui.utils.shareText
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.emptyFlow
 
 @Composable
@@ -169,7 +170,7 @@ private fun TransferDetailsScreen(
     }
     val transferFlow = remember { snapshotFlow { getTransfer() } }
     LaunchedEffect(Unit) {
-        transferFlow.collect { transfer ->
+        transferFlow.collectLatest { transfer ->
             val singleFileOrNull = transfer.files.singleOrNull()
             runDownloadUi(downloadUi, transfer, singleFileOrNull)
         }


### PR DESCRIPTION
This is certainly what caused the download button to not update on tablets (mater/details UI) when selecting another transfer in the list.