### PR TITLE
chore: Declare handled config changes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -78,6 +78,7 @@
 
         <activity
             android:name=".ui.LaunchActivity"
+            android:configChanges="colorMode|density|fontScale|fontWeightAdjustment|grammaticalGender|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"
             android:exported="true"
             android:theme="@style/Theme.AppStarting">
             <intent-filter>
@@ -105,10 +106,13 @@
             </intent-filter>
         </activity>
 
-        <activity android:name=".ui.OnboardingActivity" />
+        <activity
+            android:name=".ui.OnboardingActivity"
+            android:configChanges="colorMode|density|fontScale|fontWeightAdjustment|grammaticalGender|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode" />
 
         <activity
             android:name=".ui.MainActivity"
+            android:configChanges="colorMode|density|fontScale|fontWeightAdjustment|grammaticalGender|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"
             android:launchMode="singleTask" />
 
         <!-- We need NewMessageActivity to have its standard launchMode in the Manifest

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/FilePreview.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/FilePreview.kt
@@ -73,7 +73,7 @@ private val videoFrameDecoderFactory = VideoFrameDecoder.Factory()
 @Composable
 private fun FileThumbnail(uri: String, onError: () -> Unit) {
     val context = LocalContext.current
-    val imageRequest = remember(uri) {
+    val imageRequest = remember(uri, context) {
         ImageRequest.Builder(context)
             .data(uri)
             .decoderFactory(videoFrameDecoderFactory)

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/components/MainScaffold.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/components/MainScaffold.kt
@@ -99,7 +99,7 @@ private fun rememberNavType(
 
     val context = LocalContext.current
 
-    return remember(showNavigation, windowAdaptiveInfo) {
+    return remember(context, showNavigation, windowAdaptiveInfo) {
         if (showNavigation) {
             calculateFromAdaptiveInfo(context, windowAdaptiveInfo)
         } else {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/components/Progress.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/components/Progress.kt
@@ -64,7 +64,7 @@ private fun Percentage(uploadedSizeInBytes: () -> Long, totalSizeInBytes: Long) 
 @Composable
 private fun UploadedSize(uploadedSizeInBytes: () -> Long) {
     val context = LocalContext.current
-    val humanReadableSize by remember {
+    val humanReadableSize by remember(context) {
         derivedStateOf { HumanReadableSizeUtils.getHumanReadableSize(context, uploadedSizeInBytes()) }
     }
 
@@ -77,7 +77,7 @@ private fun UploadedSize(uploadedSizeInBytes: () -> Long) {
 @Composable
 private fun TotalSize(totalSizeInBytes: Long) {
     val context = LocalContext.current
-    val humanReadableTotalSize by remember {
+    val humanReadableTotalSize by remember(context) {
         derivedStateOf { HumanReadableSizeUtils.getHumanReadableSize(context, totalSizeInBytes) }
     }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/validateemail/ValidateUserEmailScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/validateemail/ValidateUserEmailScreen.kt
@@ -108,7 +108,7 @@ fun HandleValidationStatus(
     snackbarHostState: SnackbarHostState,
 ) {
     val context = LocalContext.current
-    LaunchedEffect(sendStatus()) {
+    LaunchedEffect(sendStatus(), context) {
         when (val status = sendStatus()) {
             is TransferSendManager.SendStatus.Success -> navigateToUploadInProgress(status.totalSize)
             is TransferSendManager.SendStatus.Failure -> {
@@ -126,7 +126,7 @@ fun HandleValidationStatus(
 fun HandleUnknownValidationError(uiState: () -> ValidateEmailUiState, snackbarHostState: SnackbarHostState) {
     val context = LocalContext.current
 
-    LaunchedEffect(uiState()) {
+    LaunchedEffect(uiState(), context) {
         when (uiState()) {
             ValidateEmailUiState.UnknownError -> {
                 SentryLog.e("Email validation", "An unknown API error has occurred when validating the OTP code")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 buildscript {
     extra.apply {
-        set("appCompileSdk", 35)
+        set("appCompileSdk", 35) // Ensure any extra configChanges are added into Activities' manifests.
         set("appMinSdk", 24)
         set("javaVersion", JavaVersion.VERSION_17)
     }


### PR DESCRIPTION
This is safe to do since all the APIs we use in Compose should already handle configChanges.

I made sure that `Context` objects are used as a remember keys when applicable.