### PR TITLE
feat: Define the file import progress as amount bytes instead of amount of files

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
@@ -96,8 +96,8 @@ class ImportFilesViewModel @Inject constructor(
         )
 
     val filesToImportCount = importationFilesManager.filesToImportCount
-    val importedByteCount = importationFilesManager.importedByteCount
-    val currentSessionByteCount = importationFilesManager.currentSessionByteCount
+    val currentSessionImportedByteCount = importationFilesManager.currentSessionImportedByteCount
+    val currentSessionTotalByteCount = importationFilesManager.currentSessionTotalByteCount
 
     sealed interface FilesDetailsUiState {
         data object EmptyFiles : FilesDetailsUiState

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
@@ -72,7 +72,7 @@ class ImportFilesViewModel @Inject constructor(
 
     val sendStatus by transferSendManager::sendStatus
 
-    private val _sendButtonStatus: MutableStateFlow<SendButtonStatus> = MutableStateFlow(SendButtonStatus.Available)
+    private val _sendButtonStatus: MutableStateFlow<SendButtonStatus> = MutableStateFlow(SendButtonStatus.Clickable)
     val sendButtonStatus: StateFlow<SendButtonStatus> = _sendButtonStatus.asStateFlow()
 
     val filesDetailsUiState = importationFilesManager.importedFiles.map {
@@ -170,7 +170,7 @@ class ImportFilesViewModel @Inject constructor(
             _sendButtonStatus.value = if (fileCount > 0) {
                 SendButtonStatus.Progress(importedBytes / totalBytes.toFloat())
             } else {
-                SendButtonStatus.Available
+                SendButtonStatus.Clickable
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
@@ -95,9 +95,9 @@ class ImportFilesViewModel @Inject constructor(
             initialValue = emptyList(),
         )
 
-    val filesToImportCount = importationFilesManager.filesToImportCount
-    val currentSessionImportedByteCount = importationFilesManager.currentSessionImportedByteCount
-    val currentSessionTotalByteCount = importationFilesManager.currentSessionTotalByteCount
+    val filesToImportCount: StateFlow<Int> = importationFilesManager.filesToImportCount
+    val currentSessionImportedByteCount: StateFlow<Long> = importationFilesManager.currentSessionImportedByteCount
+    val currentSessionTotalByteCount: StateFlow<Long> = importationFilesManager.currentSessionTotalByteCount
 
     sealed interface FilesDetailsUiState {
         data object EmptyFiles : FilesDetailsUiState

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
@@ -96,7 +96,8 @@ class ImportFilesViewModel @Inject constructor(
         )
 
     val filesToImportCount = importationFilesManager.filesToImportCount
-    val currentSessionFilesCount = importationFilesManager.currentSessionFilesCount
+    val importedByteCount = importationFilesManager.importedByteCount
+    val currentSessionByteCount = importationFilesManager.currentSessionByteCount
 
     sealed interface FilesDetailsUiState {
         data object EmptyFiles : FilesDetailsUiState

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportLocalStorage.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportLocalStorage.kt
@@ -38,7 +38,7 @@ class ImportLocalStorage @Inject constructor(@ApplicationContext private val app
     val copiedBytes: StateFlow<Long> = _copiedBytes.asStateFlow()
 
     /**
-     * This method is used to reset the copied bytes the transfer count session is reset
+     * This method is used to reset the copied bytes when the session is reset
      */
     fun resetCopiedBytes() {
         _copiedBytes.update { 0 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportationFilesManager.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportationFilesManager.kt
@@ -54,8 +54,8 @@ class ImportationFilesManager @Inject constructor(
         resetCopiedBytes = { importLocalStorage.resetCopiedBytes() }
     )
     val filesToImportCount: StateFlow<Int> = filesToImportChannel.count
-    val currentSessionByteCount: StateFlow<Long> = filesToImportChannel.currentSessionByteCount
-    val importedByteCount by importLocalStorage::copiedBytes
+    val currentSessionTotalByteCount: StateFlow<Long> = filesToImportChannel.currentSessionTotalByteCount
+    val currentSessionImportedByteCount by importLocalStorage::copiedBytes
 
     private val _importedFiles = FilesMutableStateFlow()
     val importedFiles = _importedFiles.flow

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportationFilesManager.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportationFilesManager.kt
@@ -55,7 +55,7 @@ class ImportationFilesManager @Inject constructor(
     )
     val filesToImportCount: StateFlow<Int> = filesToImportChannel.count
     val currentSessionTotalByteCount: StateFlow<Long> = filesToImportChannel.currentSessionTotalByteCount
-    val currentSessionImportedByteCount by importLocalStorage::copiedBytes
+    val currentSessionImportedByteCount: StateFlow<Long> by importLocalStorage::copiedBytes
 
     private val _importedFiles = FilesMutableStateFlow()
     val importedFiles = _importedFiles.flow

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportationFilesManager.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportationFilesManager.kt
@@ -51,6 +51,7 @@ class ImportationFilesManager @Inject constructor(
 ) {
 
     private val filesToImportChannel: TransferCountChannel = TransferCountChannel(
+        context = appContext,
         resetCopiedBytes = { importLocalStorage.resetCopiedBytes() }
     )
     val filesToImportCount: StateFlow<Int> = filesToImportChannel.count
@@ -67,7 +68,7 @@ class ImportationFilesManager @Inject constructor(
     private val alreadyUsedFileNames = AlreadyUsedFileNamesSet()
 
     suspend fun importFiles(uris: List<Uri>) {
-        uris.extractPickedFiles().forEach { filesToImportChannel.send(it, appContext) }
+        uris.extractPickedFiles().forEach { filesToImportChannel.send(it) }
     }
 
     suspend fun removeFileByUid(uid: String) {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportationFilesManager.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportationFilesManager.kt
@@ -51,7 +51,6 @@ class ImportationFilesManager @Inject constructor(
 ) {
 
     private val filesToImportChannel: TransferCountChannel = TransferCountChannel(
-        context = appContext,
         resetCopiedBytes = importLocalStorage::resetCopiedBytes,
     )
     val filesToImportCount: StateFlow<Int> = filesToImportChannel.count
@@ -68,7 +67,9 @@ class ImportationFilesManager @Inject constructor(
     private val alreadyUsedFileNames = AlreadyUsedFileNamesSet()
 
     suspend fun importFiles(uris: List<Uri>) {
-        uris.extractPickedFiles().forEach { filesToImportChannel.send(it) }
+        val pickedFiles = uris.extractPickedFiles()
+        filesToImportChannel.setTotalFileSize(pickedFiles.sumOf { it.fileSize })
+        pickedFiles.forEach { filesToImportChannel.send(it) }
     }
 
     suspend fun removeFileByUid(uid: String) {
@@ -172,7 +173,7 @@ class ImportationFilesManager @Inject constructor(
         val contentResolver: ContentResolver = appContext.contentResolver
         val cursor: Cursor? = contentResolver.query(uri, null, null, null, null)
 
-        return cursor?.getFileName()?.let { name ->
+        return cursor?.getFileNameAndSize()?.let { (name, size) ->
             val uniqueName = alreadyUsedFileNames.addUniqueFileName(computeUniqueFileName = { alreadyUsedStrategy ->
                 FileNameUtils.postfixExistingFileNames(
                     fileName = name,
@@ -180,14 +181,19 @@ class ImportationFilesManager @Inject constructor(
                 )
             })
 
-            PickedFile(uniqueName, uri)
+            PickedFile(uniqueName, uri, size)
         }
     }
 
-    private fun Cursor.getFileName(): String? = use {
+    private fun Cursor.getFileNameAndSize(): Pair<String, Long>? = use {
         if (it.moveToFirst()) {
             val displayNameColumnIndex = it.getColumnIndexOrNull(OpenableColumns.DISPLAY_NAME) ?: return null
-            it.getString(displayNameColumnIndex)
+            val fileName = it.getString(displayNameColumnIndex)
+
+            val fileSizeColumnIndex = it.getColumnIndexOrNull(OpenableColumns.SIZE) ?: return null
+            val fileSize = it.getLong(fileSizeColumnIndex)
+
+            fileName to fileSize
         } else {
             null
         }
@@ -208,7 +214,7 @@ class ImportationFilesManager @Inject constructor(
         }
     }
 
-    data class PickedFile(val fileName: String, val uri: Uri)
+    data class PickedFile(val fileName: String, val uri: Uri, val fileSize: Long)
 
     companion object {
         private const val TAG = "File importation"

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportationFilesManager.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportationFilesManager.kt
@@ -52,7 +52,7 @@ class ImportationFilesManager @Inject constructor(
 
     private val filesToImportChannel: TransferCountChannel = TransferCountChannel(
         context = appContext,
-        resetCopiedBytes = { importLocalStorage.resetCopiedBytes() }
+        resetCopiedBytes = importLocalStorage::resetCopiedBytes,
     )
     val filesToImportCount: StateFlow<Int> = filesToImportChannel.count
     val currentSessionTotalByteCount: StateFlow<Long> = filesToImportChannel.currentSessionTotalByteCount

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/SendButtonStatus.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/SendButtonStatus.kt
@@ -21,6 +21,8 @@ import androidx.annotation.FloatRange
 
 sealed interface SendButtonStatus {
     data object Available : SendButtonStatus
+    // This status usually only lasts for a split seconds if the user doesn't pick multiple hundred of files. So this prevents the
+    // button from being clicked but doesn't show a jarring blinking button to the user.
     data object Unclickable : SendButtonStatus
     data class Progress(@FloatRange(0.0, 1.0) val progress: Float) : SendButtonStatus
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/SendButtonStatus.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/SendButtonStatus.kt
@@ -20,7 +20,7 @@ package com.infomaniak.swisstransfer.ui.screen.newtransfer
 import androidx.annotation.FloatRange
 
 sealed interface SendButtonStatus {
-    data object Available : SendButtonStatus
+    data object Clickable : SendButtonStatus
     // This status usually only lasts for a split seconds if the user doesn't pick multiple hundred of files. So this prevents the
     // button from being clicked but doesn't show a jarring blinking button to the user.
     data object Unclickable : SendButtonStatus

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/SendButtonStatus.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/SendButtonStatus.kt
@@ -1,0 +1,26 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.swisstransfer.ui.screen.newtransfer
+
+import androidx.annotation.FloatRange
+
+sealed interface SendButtonStatus {
+    data object Available : SendButtonStatus
+    data object Unclickable : SendButtonStatus
+    data class Progress(@FloatRange(0.0, 1.0) val progress: Float) : SendButtonStatus
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferCountChannel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferCountChannel.kt
@@ -40,7 +40,7 @@ class TransferCountChannel(private val resetCopiedBytes: () -> Unit) {
      * This count is used to track and compute the progress of files being imported during the current session.
      */
     private val _currentSessionByteCount: MutableStateFlow<Long> = MutableStateFlow(0)
-    val currentSessionByteCount: StateFlow<Long> = _currentSessionByteCount.asStateFlow()
+    val currentSessionTotalByteCount: StateFlow<Long> = _currentSessionByteCount.asStateFlow()
 
     private val countMutex = Mutex()
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferCountChannel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferCountChannel.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
-class TransferCountChannel(private val resetCopiedBytes: () -> Unit) {
+class TransferCountChannel(private val context: Context, private val resetCopiedBytes: () -> Unit) {
     private val channel = Channel<ImportationFilesManager.PickedFile>(capacity = Channel.UNLIMITED)
 
     private val _count = MutableStateFlow(0)
@@ -44,7 +44,7 @@ class TransferCountChannel(private val resetCopiedBytes: () -> Unit) {
 
     private val countMutex = Mutex()
 
-    suspend fun send(element: ImportationFilesManager.PickedFile, context: Context) {
+    suspend fun send(element: ImportationFilesManager.PickedFile) {
         countMutex.withLock {
             _count.value += 1
             _currentSessionByteCount.update { it + element.uri.getFileSize(context) }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferCountChannel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferCountChannel.kt
@@ -59,7 +59,7 @@ class TransferCountChannel(private val resetCopiedBytes: () -> Unit) {
 
     suspend fun setTotalFileSize(totalFileSize: Long) {
         countMutex.withLock {
-            _currentSessionByteCount.value = totalFileSize
+            _currentSessionByteCount.value += totalFileSize
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferCountChannel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferCountChannel.kt
@@ -17,14 +17,19 @@
  */
 package com.infomaniak.swisstransfer.ui.screen.newtransfer
 
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import com.infomaniak.core.sentry.SentryLog
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
-class TransferCountChannel {
+class TransferCountChannel(private val resetCopiedBytes: () -> Unit) {
     private val channel = Channel<ImportationFilesManager.PickedFile>(capacity = Channel.UNLIMITED)
 
     private val _count = MutableStateFlow(0)
@@ -34,15 +39,15 @@ class TransferCountChannel {
      * A "session" lasts from when the queue count is greater than 0 until it resets to 0 again.
      * This count is used to track and compute the progress of files being imported during the current session.
      */
-    private val _currentSessionFilesCount = MutableStateFlow(0)
-    val currentSessionFilesCount: StateFlow<Int> = _currentSessionFilesCount
+    private val _currentSessionByteCount: MutableStateFlow<Long> = MutableStateFlow(0)
+    val currentSessionByteCount: StateFlow<Long> = _currentSessionByteCount.asStateFlow()
 
     private val countMutex = Mutex()
 
-    suspend fun send(element: ImportationFilesManager.PickedFile) {
+    suspend fun send(element: ImportationFilesManager.PickedFile, context: Context) {
         countMutex.withLock {
             _count.value += 1
-            _currentSessionFilesCount.value += 1
+            _currentSessionByteCount.update { it + element.uri.getFileSize(context) }
         }
         channel.send(element)
     }
@@ -52,7 +57,28 @@ class TransferCountChannel {
             process(element)
             countMutex.withLock {
                 _count.value -= 1
-                if (_count.value == 0) _currentSessionFilesCount.value = 0
+                if (_count.value == 0) {
+                    _currentSessionByteCount.update { 0 }
+                    resetCopiedBytes()
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val TAG = TransferCountChannel::class.java.simpleName
+
+        private fun Uri.getFileSize(context: Context): Long {
+            return context.contentResolver.query(this, null, null, null, null)?.use { cursor ->
+                val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
+                if (sizeIndex != -1 && cursor.moveToFirst()) {
+                    cursor.getLong(sizeIndex)
+                } else {
+                    null
+                }
+            } ?: run {
+                SentryLog.e(TAG, "Could not read file size when importing a new file")
+                0
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferCountChannel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferCountChannel.kt
@@ -34,8 +34,8 @@ class TransferCountChannel(private val resetCopiedBytes: () -> Unit) {
      * A "session" lasts from when the queue count is greater than 0 until it resets to 0 again.
      * This count is used to track and compute the progress of files being imported during the current session.
      */
-    private val _currentSessionByteCount: MutableStateFlow<Long> = MutableStateFlow(0)
-    val currentSessionTotalByteCount: StateFlow<Long> = _currentSessionByteCount.asStateFlow()
+    private val _currentSessionTotalByteCount: MutableStateFlow<Long> = MutableStateFlow(0)
+    val currentSessionTotalByteCount: StateFlow<Long> = _currentSessionTotalByteCount.asStateFlow()
 
     private val countMutex = Mutex()
 
@@ -50,7 +50,7 @@ class TransferCountChannel(private val resetCopiedBytes: () -> Unit) {
             countMutex.withLock {
                 _count.value -= 1
                 if (_count.value == 0) {
-                    _currentSessionByteCount.value = 0
+                    _currentSessionTotalByteCount.value = 0
                     resetCopiedBytes()
                 }
             }
@@ -59,7 +59,7 @@ class TransferCountChannel(private val resetCopiedBytes: () -> Unit) {
 
     suspend fun setTotalFileSize(totalFileSize: Long) {
         countMutex.withLock {
-            _currentSessionByteCount.value += totalFileSize
+            _currentSessionTotalByteCount.value += totalFileSize
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferCountChannel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferCountChannel.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -49,7 +48,7 @@ class TransferCountChannel(private val context: Context, private val resetCopied
 
         countMutex.withLock {
             _count.value += 1
-            _currentSessionByteCount.update { it + fileSize }
+            _currentSessionByteCount.value += fileSize
         }
         channel.send(element)
     }
@@ -60,7 +59,7 @@ class TransferCountChannel(private val context: Context, private val resetCopied
             countMutex.withLock {
                 _count.value -= 1
                 if (_count.value == 0) {
-                    _currentSessionByteCount.update { 0 }
+                    _currentSessionByteCount.value = 0
                     resetCopiedBytes()
                 }
             }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferCountChannel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferCountChannel.kt
@@ -45,9 +45,11 @@ class TransferCountChannel(private val context: Context, private val resetCopied
     private val countMutex = Mutex()
 
     suspend fun send(element: ImportationFilesManager.PickedFile) {
+        val fileSize = element.uri.getFileSize(context)
+
         countMutex.withLock {
             _count.value += 1
-            _currentSessionByteCount.update { it + element.uri.getFileSize(context) }
+            _currentSessionByteCount.update { it + fileSize }
         }
         channel.send(element)
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -554,7 +554,7 @@ private fun Preview(@PreviewParameter(FileUiListPreviewParameter::class) files: 
     SwissTransferTheme {
         ImportFilesScreen(
             files = { files },
-            sendButtonStatus = { SendButtonStatus.Available },
+            sendButtonStatus = { SendButtonStatus.Clickable },
             emailTextFieldCallbacks = emailTextFieldCallbacks,
             transferMessageCallbacks = GetSetCallbacks(get = { "" }, set = {}),
             selectedTransferType = GetSetCallbacks(get = { TransferTypeUi.Mail }, set = {}),

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -83,8 +83,8 @@ fun ImportFilesScreen(
 
     val files by importFilesViewModel.importedFilesDebounced.collectAsStateWithLifecycle()
     val filesToImportCount by importFilesViewModel.filesToImportCount.collectAsStateWithLifecycle()
-    val importedByteCount by importFilesViewModel.importedByteCount.collectAsStateWithLifecycle()
-    val currentSessionByteCount by importFilesViewModel.currentSessionByteCount.collectAsStateWithLifecycle()
+    val importedByteCount by importFilesViewModel.currentSessionImportedByteCount.collectAsStateWithLifecycle()
+    val totalByteCount by importFilesViewModel.currentSessionTotalByteCount.collectAsStateWithLifecycle()
 
     val selectedTransferType by importFilesViewModel.selectedTransferType.collectAsStateWithLifecycle()
 
@@ -166,7 +166,7 @@ fun ImportFilesScreen(
         files = { files },
         filesToImportCount = { filesToImportCount },
         importedByteCount = { importedByteCount },
-        currentSessionByteCount = { currentSessionByteCount },
+        totalByteCount = { totalByteCount },
         emailTextFieldCallbacks = emailTextFieldCallbacks,
         transferMessageCallbacks = importFilesViewModel.transferMessageCallbacks,
         selectedTransferType = GetSetCallbacks(
@@ -241,7 +241,7 @@ private fun ImportFilesScreen(
     files: () -> List<FileUi>,
     filesToImportCount: () -> Int,
     importedByteCount: () -> Long,
-    currentSessionByteCount: () -> Long,
+    totalByteCount: () -> Long,
     emailTextFieldCallbacks: EmailTextFieldCallbacks,
     transferMessageCallbacks: GetSetCallbacks<String>,
     selectedTransferType: GetSetCallbacks<TransferTypeUi>,
@@ -277,7 +277,7 @@ private fun ImportFilesScreen(
                 modifier = modifier,
                 filesToImportCount = filesToImportCount,
                 importedByteCount = importedByteCount,
-                currentSessionByteCount = currentSessionByteCount,
+                totalByteCount = totalByteCount,
                 importedFiles = files,
                 areEmailsCorrects = { areEmailsCorrects },
                 sendStatus = sendStatus,
@@ -458,7 +458,7 @@ private fun SendButton(
     modifier: Modifier,
     filesToImportCount: () -> Int,
     importedByteCount: () -> Long,
-    currentSessionByteCount: () -> Long,
+    totalByteCount: () -> Long,
     importedFiles: () -> List<FileUi>,
     areEmailsCorrects: () -> Boolean,
     sendStatus: () -> SendStatus,
@@ -466,7 +466,7 @@ private fun SendButton(
 ) {
     val isImporting by remember { derivedStateOf { filesToImportCount() > 0 } }
 
-    val importProgress = importedByteCount() / currentSessionByteCount().toFloat()
+    val importProgress = importedByteCount() / totalByteCount().toFloat()
     val progress: (() -> Float)? = if (isImporting) fun() = importProgress else null
 
     LargeButton(
@@ -565,7 +565,7 @@ private fun Preview(@PreviewParameter(FileUiListPreviewParameter::class) files: 
             files = { files },
             filesToImportCount = { 0 },
             importedByteCount = { 0 },
-            currentSessionByteCount = { 0 },
+            totalByteCount = { 0 },
             emailTextFieldCallbacks = emailTextFieldCallbacks,
             transferMessageCallbacks = GetSetCallbacks(get = { "" }, set = {}),
             selectedTransferType = GetSetCallbacks(get = { TransferTypeUi.Mail }, set = {}),

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -83,7 +83,8 @@ fun ImportFilesScreen(
 
     val files by importFilesViewModel.importedFilesDebounced.collectAsStateWithLifecycle()
     val filesToImportCount by importFilesViewModel.filesToImportCount.collectAsStateWithLifecycle()
-    val currentSessionFilesCount by importFilesViewModel.currentSessionFilesCount.collectAsStateWithLifecycle()
+    val importedByteCount by importFilesViewModel.importedByteCount.collectAsStateWithLifecycle()
+    val currentSessionByteCount by importFilesViewModel.currentSessionByteCount.collectAsStateWithLifecycle()
 
     val selectedTransferType by importFilesViewModel.selectedTransferType.collectAsStateWithLifecycle()
 
@@ -164,7 +165,8 @@ fun ImportFilesScreen(
     ImportFilesScreen(
         files = { files },
         filesToImportCount = { filesToImportCount },
-        currentSessionFilesCount = { currentSessionFilesCount },
+        importedByteCount = { importedByteCount },
+        currentSessionByteCount = { currentSessionByteCount },
         emailTextFieldCallbacks = emailTextFieldCallbacks,
         transferMessageCallbacks = importFilesViewModel.transferMessageCallbacks,
         selectedTransferType = GetSetCallbacks(
@@ -238,7 +240,8 @@ private fun HandleSendActionResult(
 private fun ImportFilesScreen(
     files: () -> List<FileUi>,
     filesToImportCount: () -> Int,
-    currentSessionFilesCount: () -> Int,
+    importedByteCount: () -> Long,
+    currentSessionByteCount: () -> Long,
     emailTextFieldCallbacks: EmailTextFieldCallbacks,
     transferMessageCallbacks: GetSetCallbacks<String>,
     selectedTransferType: GetSetCallbacks<TransferTypeUi>,
@@ -273,7 +276,8 @@ private fun ImportFilesScreen(
             SendButton(
                 modifier = modifier,
                 filesToImportCount = filesToImportCount,
-                currentSessionFilesCount = currentSessionFilesCount,
+                importedByteCount = importedByteCount,
+                currentSessionByteCount = currentSessionByteCount,
                 importedFiles = files,
                 areEmailsCorrects = { areEmailsCorrects },
                 sendStatus = sendStatus,
@@ -453,22 +457,17 @@ private fun ImportFilesTitle(modifier: Modifier = Modifier, @StringRes titleRes:
 private fun SendButton(
     modifier: Modifier,
     filesToImportCount: () -> Int,
-    currentSessionFilesCount: () -> Int,
+    importedByteCount: () -> Long,
+    currentSessionByteCount: () -> Long,
     importedFiles: () -> List<FileUi>,
     areEmailsCorrects: () -> Boolean,
     sendStatus: () -> SendStatus,
     sendTransfer: () -> Unit,
 ) {
-    val remainingFilesCount = filesToImportCount()
-    val isImporting by remember(remainingFilesCount) { derivedStateOf { remainingFilesCount > 0 } }
+    val isImporting by remember { derivedStateOf { filesToImportCount() > 0 } }
 
-    val total = currentSessionFilesCount()
-    val importProgress = remember(remainingFilesCount, total) { 1 - (remainingFilesCount.toFloat() / total) }
-    val progress: (() -> Float)? = if (isImporting) {
-        { importProgress }
-    } else {
-        null
-    }
+    val importProgress = importedByteCount() / currentSessionByteCount().toFloat()
+    val progress: (() -> Float)? = if (isImporting) fun() = importProgress else null
 
     LargeButton(
         modifier = modifier,
@@ -565,7 +564,8 @@ private fun Preview(@PreviewParameter(FileUiListPreviewParameter::class) files: 
         ImportFilesScreen(
             files = { files },
             filesToImportCount = { 0 },
-            currentSessionFilesCount = { 0 },
+            importedByteCount = { 0 },
+            currentSessionByteCount = { 0 },
             emailTextFieldCallbacks = emailTextFieldCallbacks,
             transferMessageCallbacks = GetSetCallbacks(get = { "" }, set = {}),
             selectedTransferType = GetSetCallbacks(get = { TransferTypeUi.Mail }, set = {}),

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -46,6 +46,7 @@ import com.infomaniak.swisstransfer.ui.screen.main.settings.EmailLanguageOption
 import com.infomaniak.swisstransfer.ui.screen.main.settings.ValidityPeriodOption
 import com.infomaniak.swisstransfer.ui.screen.main.settings.components.SettingOption
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.ImportFilesViewModel
+import com.infomaniak.swisstransfer.ui.screen.newtransfer.SendButtonStatus
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.TransferSendManager.SendStatus
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.importfiles.components.*
 import com.infomaniak.swisstransfer.ui.theme.Margin
@@ -82,9 +83,7 @@ fun ImportFilesScreen(
     areTransferDataStillAvailable = true
 
     val files by importFilesViewModel.importedFilesDebounced.collectAsStateWithLifecycle()
-    val filesToImportCount by importFilesViewModel.filesToImportCount.collectAsStateWithLifecycle()
-    val importedByteCount by importFilesViewModel.currentSessionImportedByteCount.collectAsStateWithLifecycle()
-    val totalByteCount by importFilesViewModel.currentSessionTotalByteCount.collectAsStateWithLifecycle()
+    val sendButtonStatus by importFilesViewModel.sendButtonStatus.collectAsStateWithLifecycle()
 
     val selectedTransferType by importFilesViewModel.selectedTransferType.collectAsStateWithLifecycle()
 
@@ -164,9 +163,7 @@ fun ImportFilesScreen(
 
     ImportFilesScreen(
         files = { files },
-        filesToImportCount = { filesToImportCount },
-        importedByteCount = { importedByteCount },
-        totalByteCount = { totalByteCount },
+        sendButtonStatus = { sendButtonStatus },
         emailTextFieldCallbacks = emailTextFieldCallbacks,
         transferMessageCallbacks = importFilesViewModel.transferMessageCallbacks,
         selectedTransferType = GetSetCallbacks(
@@ -239,9 +236,7 @@ private fun HandleSendActionResult(
 @Composable
 private fun ImportFilesScreen(
     files: () -> List<FileUi>,
-    filesToImportCount: () -> Int,
-    importedByteCount: () -> Long,
-    totalByteCount: () -> Long,
+    sendButtonStatus: () -> SendButtonStatus,
     emailTextFieldCallbacks: EmailTextFieldCallbacks,
     transferMessageCallbacks: GetSetCallbacks<String>,
     selectedTransferType: GetSetCallbacks<TransferTypeUi>,
@@ -275,9 +270,7 @@ private fun ImportFilesScreen(
         topButton = { modifier ->
             SendButton(
                 modifier = modifier,
-                filesToImportCount = filesToImportCount,
-                importedByteCount = importedByteCount,
-                totalByteCount = totalByteCount,
+                sendButtonStatus = sendButtonStatus,
                 importedFiles = files,
                 areEmailsCorrects = { areEmailsCorrects },
                 sendStatus = sendStatus,
@@ -456,27 +449,25 @@ private fun ImportFilesTitle(modifier: Modifier = Modifier, @StringRes titleRes:
 @Composable
 private fun SendButton(
     modifier: Modifier,
-    filesToImportCount: () -> Int,
-    importedByteCount: () -> Long,
-    totalByteCount: () -> Long,
+    sendButtonStatus: () -> SendButtonStatus,
     importedFiles: () -> List<FileUi>,
     areEmailsCorrects: () -> Boolean,
     sendStatus: () -> SendStatus,
     sendTransfer: () -> Unit,
 ) {
-    val isImporting by remember { derivedStateOf { filesToImportCount() > 0 } }
+    fun isImporting() = sendButtonStatus() is SendButtonStatus.Progress
 
-    val importProgress = importedByteCount() / totalByteCount().toFloat()
-    val progress: (() -> Float)? = if (isImporting) fun() = importProgress else null
+    val status = sendButtonStatus()
+    val progress: (() -> Float)? = if (status is SendButtonStatus.Progress) fun() = status.progress else null
 
     LargeButton(
         modifier = modifier,
         title = stringResource(R.string.transferSendButton),
         style = ButtonType.Primary,
         showIndeterminateProgress = { sendStatus() == SendStatus.Pending },
-        enabled = { importedFiles().isNotEmpty() && !isImporting && areEmailsCorrects() && sendStatus().canEnableButton() },
+        enabled = { importedFiles().isNotEmpty() && !isImporting() && areEmailsCorrects() && sendStatus().canEnableButton() },
         progress = progress,
-        onClick = { sendTransfer() },
+        onClick = { if (sendButtonStatus() !is SendButtonStatus.Unclickable) sendTransfer() },
     )
 }
 
@@ -563,9 +554,7 @@ private fun Preview(@PreviewParameter(FileUiListPreviewParameter::class) files: 
     SwissTransferTheme {
         ImportFilesScreen(
             files = { files },
-            filesToImportCount = { 0 },
-            importedByteCount = { 0 },
-            totalByteCount = { 0 },
+            sendButtonStatus = { SendButtonStatus.Available },
             emailTextFieldCallbacks = emailTextFieldCallbacks,
             transferMessageCallbacks = GetSetCallbacks(get = { "" }, set = {}),
             selectedTransferType = GetSetCallbacks(get = { TransferTypeUi.Mail }, set = {}),


### PR DESCRIPTION
The file progress when importing is now continuous because it counts the copied bytes instead of couting the number of copied files which is very limited to visually indicate the progress