### PR TITLE
feat: Move integrity token call to the upload progress screen

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/NewTransferActivity.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/NewTransferActivity.kt
@@ -100,12 +100,14 @@ class NewTransferActivity : ComponentActivity() {
             value = intent?.extras?.getString(NOTIFICATION_NAVIGATION_KEY),
         )
         val transferType = enumValueOfOrNull<TransferTypeUi>(intent?.extras?.getString(TRANSFER_TYPE_KEY))
+        val authorEmail = intent?.extras?.getString(TRANSFER_AUTHOR_EMAIL_KEY)
 
         return when (notificationNavigation) {
             NotificationNavigation.UploadProgress -> {
                 NewTransferNavigation.UploadProgressDestination(
                     transferType = transferType!!,
                     totalSize = intent?.extras?.getLong(TRANSFER_TOTAL_SIZE_KEY)!!,
+                    authorEmail = authorEmail,
                 )
             }
             NotificationNavigation.UploadSuccess -> {
@@ -119,6 +121,7 @@ class NewTransferActivity : ComponentActivity() {
                 NewTransferNavigation.UploadErrorDestination(
                     transferType = transferType!!,
                     totalSize = intent?.extras?.getLong(TRANSFER_TOTAL_SIZE_KEY)!!,
+                    authorEmail = authorEmail,
                 )
             }
             null -> NewTransferNavigation.startDestination

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/images/illus/appIntegrity/GhostScrollCrossPointing.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/images/illus/appIntegrity/GhostScrollCrossPointing.kt
@@ -1,0 +1,56 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.swisstransfer.ui.images.illus.appIntegrity
+
+import android.content.res.Configuration
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.infomaniak.swisstransfer.ui.images.AppImages
+import com.infomaniak.swisstransfer.ui.images.AppImages.AppIllus
+import com.infomaniak.swisstransfer.ui.images.ThemedImage
+import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
+
+val AppIllus.GhostScrollCrossPointing: ThemedImage
+    get() = _ghostScrollCrossPointing ?: object : ThemedImage {
+        override val light = AppIllus.GhostScrollCrossPointingLight
+        override val dark = AppIllus.GhostScrollCrossPointingDark
+    }.also { _ghostScrollCrossPointing = it }
+
+private var _ghostScrollCrossPointing: ThemedImage? = null
+
+@Preview(name = "Light")
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)
+@Composable
+private fun Preview() {
+    SwissTransferTheme {
+        Surface {
+            Box {
+                Image(
+                    imageVector = AppIllus.GhostScrollCrossPointing.image(),
+                    contentDescription = null,
+                    modifier = Modifier.size(AppImages.previewSize),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/images/illus/appIntegrity/GhostScrollCrossPointingDark.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/images/illus/appIntegrity/GhostScrollCrossPointingDark.kt
@@ -2,7 +2,6 @@ package com.infomaniak.swisstransfer.ui.images.illus.appIntegrity
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/images/illus/appIntegrity/GhostScrollCrossPointingDark.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/images/illus/appIntegrity/GhostScrollCrossPointingDark.kt
@@ -1,0 +1,297 @@
+package com.infomaniak.swisstransfer.ui.images.illus.appIntegrity
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.EvenOdd
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.infomaniak.swisstransfer.ui.images.AppImages
+import com.infomaniak.swisstransfer.ui.images.AppImages.AppIllus
+
+val AppIllus.GhostScrollCrossPointingDark: ImageVector
+    get() {
+        if (_ghostScrollCrossPointingDark != null) {
+            return _ghostScrollCrossPointingDark!!
+        }
+        _ghostScrollCrossPointingDark = Builder(
+            name = "GhostScrollCrossPointingDark",
+            defaultWidth = 153.0.dp,
+            defaultHeight = 160.0.dp,
+            viewportWidth = 153.0f,
+            viewportHeight = 160.0f
+        ).apply {
+            path(
+                fill = SolidColor(Color(0xFF2B383B)),
+                stroke = SolidColor(Color(0xFFDCE4E5)),
+                strokeLineWidth = 1.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(49.83f, 40.44f)
+                curveTo(52.33f, 17.71f, 71.54f, 0.5f, 94.41f, 0.5f)
+                curveToRelative(22.91f, 0.0f, 42.13f, 17.26f, 44.59f, 40.03f)
+                lineToRelative(12.73f, 117.66f)
+                lineToRelative(-13.39f, -18.38f)
+                curveToRelative(-7.36f, -10.1f, -22.43f, -10.1f, -29.8f, 0.0f)
+                curveToRelative(-6.96f, 9.55f, -21.35f, 9.37f, -28.32f, -0.2f)
+                curveToRelative(-7.32f, -10.05f, -22.37f, -10.54f, -30.08f, -0.76f)
+                lineToRelative(-12.97f, 16.46f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFF152123)),
+                stroke = SolidColor(Color(0xFFDCE4E5)),
+                strokeLineWidth = 1.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(30.33f, 154.53f)
+                lineToRelative(-12.83f, 4.75f)
+                verticalLineTo(82.0f)
+                arcToRelative(9.5f, 9.5f, 0.0f, false, true, 9.5f, -9.5f)
+                horizontalLineToRelative(48.5f)
+                verticalLineToRelative(26.18f)
+                horizontalLineToRelative(-4.0f)
+                verticalLineToRelative(60.62f)
+                lineToRelative(-13.84f, -4.77f)
+                lineToRelative(-0.17f, -0.06f)
+                lineToRelative(-0.17f, 0.06f)
+                lineTo(44.0f, 159.47f)
+                lineToRelative(-13.33f, -4.94f)
+                lineToRelative(-0.17f, -0.06f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFF2B383B)),
+                stroke = SolidColor(Color(0xFFDCE4E5)),
+                strokeLineWidth = 1.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(33.31f, 107.31f)
+                arcToRelative(15.0f, 15.0f, 0.0f, true, true, 21.21f, 21.21f)
+                arcToRelative(15.0f, 15.0f, 0.0f, true, true, -21.21f, -21.21f)
+            }
+            path(
+                fill = SolidColor(Color(0xFFFF8500)),
+                stroke = null,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = EvenOdd
+            ) {
+                moveTo(53.11f, 112.26f)
+                lineToRelative(-3.54f, -3.54f)
+                lineToRelative(-5.66f, 5.66f)
+                lineToRelative(-5.66f, -5.66f)
+                lineToRelative(-3.54f, 3.54f)
+                lineToRelative(5.66f, 5.66f)
+                lineToRelative(-5.66f, 5.66f)
+                lineToRelative(3.54f, 3.54f)
+                lineToRelative(5.66f, -5.66f)
+                lineToRelative(5.66f, 5.66f)
+                lineToRelative(3.54f, -3.54f)
+                lineToRelative(-5.66f, -5.66f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFFDCE4E5)),
+                stroke = null,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(71.0f, 77.0f)
+                arcToRelative(5.0f, 5.0f, 0.0f, false, true, 10.0f, 0.0f)
+                verticalLineToRelative(31.0f)
+                horizontalLineTo(71.0f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFF2B383B)),
+                stroke = null,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(46.31f, 97.33f)
+                arcTo(7.31f, 7.31f, 0.0f, false, true, 39.0f, 90.02f)
+                verticalLineTo(73.0f)
+                horizontalLineToRelative(14.62f)
+                verticalLineToRelative(17.02f)
+                arcToRelative(7.31f, 7.31f, 0.0f, false, true, -7.31f, 7.31f)
+            }
+            path(
+                fill = null,
+                stroke = SolidColor(Color(0xFFDCE4E5)),
+                strokeLineWidth = 1.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(39.0f, 73.0f)
+                verticalLineToRelative(17.02f)
+                arcToRelative(7.31f, 7.31f, 0.0f, false, false, 14.62f, 0.0f)
+                verticalLineTo(73.0f)
+            }
+            path(
+                fill = SolidColor(Color(0xFF67DD95)),
+                stroke = null,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(83.21f, 55.73f)
+                arcToRelative(4.49f, 4.49f, 0.0f, false, true, 4.5f, 4.49f)
+                verticalLineToRelative(1.8f)
+                arcToRelative(4.49f, 4.49f, 0.0f, false, true, -4.5f, 4.5f)
+                arcToRelative(4.49f, 4.49f, 0.0f, false, true, -4.49f, -4.5f)
+                verticalLineToRelative(-1.8f)
+                arcToRelative(4.49f, 4.49f, 0.0f, false, true, 4.49f, -4.49f)
+                close()
+                moveToRelative(22.47f, 0.0f)
+                horizontalLineToRelative(0.01f)
+                arcToRelative(4.49f, 4.49f, 0.0f, false, true, 4.49f, 4.49f)
+                verticalLineToRelative(1.8f)
+                arcToRelative(4.49f, 4.49f, 0.0f, false, true, -4.49f, 4.5f)
+                horizontalLineToRelative(-0.01f)
+                arcToRelative(4.49f, 4.49f, 0.0f, false, true, -4.49f, -4.5f)
+                verticalLineToRelative(-1.8f)
+                arcToRelative(4.49f, 4.49f, 0.0f, false, true, 4.49f, -4.49f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFFDCE4E5)),
+                stroke = null,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(67.41f, 116.03f)
+                lineToRelative(49.71f, -15.73f)
+                arcToRelative(1.0f, 1.0f, 93.12f, false, true, 1.26f, 0.65f)
+                arcToRelative(1.0f, 1.0f, 93.12f, false, true, -0.65f, 1.26f)
+                lineToRelative(-49.71f, 15.73f)
+                arcToRelative(1.0f, 1.0f, 83.83f, false, true, -1.26f, -0.65f)
+                arcToRelative(1.0f, 1.0f, 83.83f, false, true, 0.65f, -1.26f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFF2B383B)),
+                stroke = null,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(114.33f, 103.14f)
+                arcToRelative(7.31f, 7.31f, 0.0f, false, true, 1.56f, -10.22f)
+                lineTo(134.81f, 79.0f)
+                lineToRelative(8.66f, 11.77f)
+                lineToRelative(-18.92f, 13.92f)
+                arcToRelative(7.31f, 7.31f, 0.0f, false, true, -10.22f, -1.56f)
+            }
+            path(
+                fill = null,
+                stroke = SolidColor(Color(0xFFDCE4E5)),
+                strokeLineWidth = 1.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(134.81f, 79.0f)
+                lineToRelative(-18.92f, 13.92f)
+                arcToRelative(7.31f, 7.31f, 0.0f, true, false, 8.66f, 11.77f)
+                lineToRelative(18.92f, -13.92f)
+            }
+            path(
+                fill = SolidColor(Color(0xFFFF8500)),
+                stroke = null,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(7.79f, 67.36f)
+                lineToRelative(-4.52f, -4.38f)
+                lineToRelative(-3.13f, -3.47f)
+                lineToRelative(1.54f, -1.39f)
+                lineToRelative(3.13f, 3.48f)
+                lineToRelative(3.88f, 4.95f)
+                close()
+                moveToRelative(2.57f, 3.78f)
+                lineToRelative(-1.64f, -1.82f)
+                lineToRelative(1.82f, -1.65f)
+                lineToRelative(1.64f, 1.83f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFFFFAA4C)),
+                stroke = null,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(21.18f, 60.63f)
+                lineToRelative(-0.75f, -6.59f)
+                lineToRelative(-0.22f, -4.93f)
+                lineToRelative(2.18f, -0.1f)
+                lineToRelative(0.22f, 4.93f)
+                lineToRelative(-0.15f, 6.64f)
+                close()
+                moveToRelative(-0.44f, 4.8f)
+                lineToRelative(-0.12f, -2.59f)
+                lineToRelative(2.59f, -0.12f)
+                lineToRelative(0.12f, 2.59f)
+                close()
+            }
+        }.build()
+        return _ghostScrollCrossPointingDark!!
+    }
+
+private var _ghostScrollCrossPointingDark: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box {
+        Image(
+            imageVector = AppIllus.GhostScrollCrossPointingDark,
+            contentDescription = null,
+            modifier = Modifier.size(AppImages.previewSize)
+        )
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/images/illus/appIntegrity/GhostScrollCrossPointingLight.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/images/illus/appIntegrity/GhostScrollCrossPointingLight.kt
@@ -1,0 +1,335 @@
+package com.infomaniak.swisstransfer.ui.images.illus.appIntegrity
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.EvenOdd
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.group
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.infomaniak.swisstransfer.ui.images.AppImages
+import com.infomaniak.swisstransfer.ui.images.AppImages.AppIllus
+
+val AppIllus.GhostScrollCrossPointingLight: ImageVector
+    get() {
+        if (_ghostScrollCrossPointingLight != null) {
+            return _ghostScrollCrossPointingLight!!
+        }
+        _ghostScrollCrossPointingLight = Builder(
+            name = "GhostScrollCrossPointingLight",
+            defaultWidth = 153.0.dp,
+            defaultHeight = 160.0.dp,
+            viewportWidth = 153.0f,
+            viewportHeight = 160.0f
+        ).apply {
+            path(
+                fill = SolidColor(Color(0xFFFFFFFF)),
+                stroke = SolidColor(Color(0xFF014958)),
+                strokeLineWidth = 1.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(49.83f, 40.44f)
+                curveTo(52.33f, 17.71f, 71.54f, 0.5f, 94.41f, 0.5f)
+                curveToRelative(22.91f, 0.0f, 42.13f, 17.26f, 44.59f, 40.03f)
+                lineToRelative(12.73f, 117.66f)
+                lineToRelative(-13.39f, -18.38f)
+                curveToRelative(-7.36f, -10.1f, -22.43f, -10.1f, -29.8f, 0.0f)
+                curveToRelative(-6.96f, 9.55f, -21.35f, 9.37f, -28.32f, -0.2f)
+                curveToRelative(-7.32f, -10.05f, -22.37f, -10.54f, -30.08f, -0.76f)
+                lineToRelative(-12.97f, 16.46f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFFFAFAFA)),
+                stroke = SolidColor(Color(0xFF014958)),
+                strokeLineWidth = 1.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(30.33f, 154.53f)
+                lineToRelative(-12.83f, 4.75f)
+                verticalLineTo(82.0f)
+                arcToRelative(9.5f, 9.5f, 0.0f, false, true, 9.5f, -9.5f)
+                horizontalLineToRelative(48.5f)
+                verticalLineToRelative(26.18f)
+                horizontalLineToRelative(-4.0f)
+                verticalLineToRelative(60.62f)
+                lineToRelative(-13.84f, -4.77f)
+                lineToRelative(-0.17f, -0.06f)
+                lineToRelative(-0.17f, 0.06f)
+                lineTo(44.0f, 159.47f)
+                lineToRelative(-13.33f, -4.94f)
+                lineToRelative(-0.17f, -0.06f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFFFFFFFF)),
+                stroke = SolidColor(Color(0xFF014958)),
+                strokeLineWidth = 1.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(33.31f, 107.31f)
+                arcToRelative(15.0f, 15.0f, 0.0f, true, true, 21.21f, 21.21f)
+                arcToRelative(15.0f, 15.0f, 0.0f, true, true, -21.21f, -21.21f)
+            }
+            path(
+                fill = SolidColor(Color(0xFFFF8500)),
+                stroke = null,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = EvenOdd
+            ) {
+                moveTo(53.11f, 112.26f)
+                lineToRelative(-3.54f, -3.54f)
+                lineToRelative(-5.66f, 5.66f)
+                lineToRelative(-5.66f, -5.66f)
+                lineToRelative(-3.54f, 3.54f)
+                lineToRelative(5.66f, 5.66f)
+                lineToRelative(-5.66f, 5.66f)
+                lineToRelative(3.54f, 3.54f)
+                lineToRelative(5.66f, -5.66f)
+                lineToRelative(5.66f, 5.66f)
+                lineToRelative(3.54f, -3.54f)
+                lineToRelative(-5.66f, -5.66f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFF014958)),
+                stroke = null,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(71.0f, 77.0f)
+                arcToRelative(5.0f, 5.0f, 0.0f, false, true, 10.0f, 0.0f)
+                verticalLineToRelative(31.0f)
+                horizontalLineTo(71.0f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFF3CB572)),
+                stroke = null,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(83.21f, 55.73f)
+                arcToRelative(4.49f, 4.49f, 0.0f, false, true, 4.5f, 4.49f)
+                verticalLineToRelative(1.8f)
+                arcToRelative(4.49f, 4.49f, 0.0f, false, true, -4.5f, 4.5f)
+                arcToRelative(4.49f, 4.49f, 0.0f, false, true, -4.49f, -4.5f)
+                verticalLineToRelative(-1.8f)
+                arcToRelative(4.49f, 4.49f, 0.0f, false, true, 4.49f, -4.49f)
+                close()
+                moveToRelative(22.47f, 0.0f)
+                horizontalLineToRelative(0.01f)
+                arcToRelative(4.49f, 4.49f, 0.0f, false, true, 4.49f, 4.49f)
+                verticalLineToRelative(1.8f)
+                arcToRelative(4.49f, 4.49f, 0.0f, false, true, -4.49f, 4.5f)
+                horizontalLineToRelative(-0.01f)
+                arcToRelative(4.49f, 4.49f, 0.0f, false, true, -4.49f, -4.5f)
+                verticalLineToRelative(-1.8f)
+                arcToRelative(4.49f, 4.49f, 0.0f, false, true, 4.49f, -4.49f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFF014958)),
+                stroke = null,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(67.41f, 116.03f)
+                lineToRelative(49.71f, -15.73f)
+                arcToRelative(1.0f, 1.0f, 93.12f, false, true, 1.26f, 0.65f)
+                arcToRelative(1.0f, 1.0f, 93.12f, false, true, -0.65f, 1.26f)
+                lineToRelative(-49.71f, 15.73f)
+                arcToRelative(1.0f, 1.0f, 83.83f, false, true, -1.26f, -0.65f)
+                arcToRelative(1.0f, 1.0f, 83.83f, false, true, 0.65f, -1.26f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFFFFFFFF)),
+                stroke = null,
+                strokeLineWidth = 0.0f,
+                strokeLineCap = Butt,
+                strokeLineJoin = Miter,
+                strokeLineMiter = 4.0f,
+                pathFillType = NonZero
+            ) {
+                moveTo(127.26f, 103.58f)
+                arcToRelative(7.78f, 7.78f, 0.0f, false, true, -9.23f, -12.54f)
+                lineTo(135.76f, 78.0f)
+                lineToRelative(9.23f, 12.54f)
+                close()
+            }
+            group {
+                path(
+                    fill = SolidColor(Color(0xFF014958)),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero
+                ) {
+                    moveTo(127.85f, 104.39f)
+                    arcToRelative(8.78f, 8.78f, 0.0f, false, true, -10.41f, -14.15f)
+                    lineToRelative(1.19f, 1.61f)
+                    arcToRelative(6.78f, 6.78f, 0.0f, false, false, 8.04f, 10.93f)
+                    close()
+                    moveTo(135.76f, 78.0f)
+                    lineToRelative(9.23f, 12.54f)
+                    close()
+                    moveToRelative(9.82f, 13.35f)
+                    lineToRelative(-17.73f, 13.04f)
+                    arcToRelative(8.78f, 8.78f, 0.0f, false, true, -12.28f, -1.87f)
+                    lineToRelative(1.61f, -1.18f)
+                    arcToRelative(6.78f, 6.78f, 0.0f, false, false, 9.48f, 1.44f)
+                    lineToRelative(17.73f, -13.04f)
+                    close()
+                    moveToRelative(-30.01f, 11.17f)
+                    arcToRelative(8.78f, 8.78f, 0.0f, false, true, 1.87f, -12.28f)
+                    lineToRelative(17.73f, -13.04f)
+                    lineToRelative(1.18f, 1.61f)
+                    lineToRelative(-17.73f, 13.05f)
+                    arcToRelative(6.78f, 6.78f, 0.0f, false, false, -1.44f, 9.48f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0xFFFFFFFF)),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero
+                ) {
+                    moveTo(35.0f, 88.59f)
+                    arcToRelative(7.78f, 7.78f, 0.0f, true, false, 15.57f, 0.0f)
+                    verticalLineTo(73.0f)
+                    horizontalLineTo(35.0f)
+                    close()
+                }
+            }
+            group {
+                path(
+                    fill = SolidColor(Color(0xFF014958)),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero
+                ) {
+                    moveTo(34.0f, 88.59f)
+                    arcToRelative(8.78f, 8.78f, 0.0f, false, false, 17.57f, 0.0f)
+                    horizontalLineToRelative(-2.0f)
+                    arcToRelative(6.78f, 6.78f, 0.0f, true, true, -13.57f, 0.0f)
+                    close()
+                    moveTo(50.57f, 73.0f)
+                    horizontalLineTo(35.0f)
+                    close()
+                    moveTo(34.0f, 73.0f)
+                    verticalLineToRelative(15.59f)
+                    arcToRelative(8.78f, 8.78f, 0.0f, false, false, 8.78f, 8.78f)
+                    verticalLineToRelative(-2.0f)
+                    arcTo(6.78f, 6.78f, 0.0f, false, true, 36.0f, 88.59f)
+                    verticalLineTo(73.0f)
+                    close()
+                    moveToRelative(8.78f, 24.37f)
+                    arcToRelative(8.78f, 8.78f, 0.0f, false, false, 8.78f, -8.78f)
+                    lineTo(51.57f, 73.0f)
+                    horizontalLineToRelative(-2.0f)
+                    verticalLineToRelative(15.59f)
+                    arcToRelative(6.78f, 6.78f, 0.0f, false, true, -6.78f, 6.78f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0xFFFF8500)),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero
+                ) {
+                    moveTo(7.79f, 67.36f)
+                    lineToRelative(-4.52f, -4.38f)
+                    lineToRelative(-3.13f, -3.47f)
+                    lineToRelative(1.54f, -1.39f)
+                    lineToRelative(3.13f, 3.48f)
+                    lineToRelative(3.88f, 4.95f)
+                    close()
+                    moveToRelative(2.57f, 3.78f)
+                    lineToRelative(-1.64f, -1.82f)
+                    lineToRelative(1.82f, -1.65f)
+                    lineToRelative(1.64f, 1.83f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0xFFFFAA4C)),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero
+                ) {
+                    moveTo(21.18f, 60.63f)
+                    lineToRelative(-0.75f, -6.59f)
+                    lineToRelative(-0.22f, -4.93f)
+                    lineToRelative(2.18f, -0.1f)
+                    lineToRelative(0.22f, 4.93f)
+                    lineToRelative(-0.15f, 6.64f)
+                    close()
+                    moveToRelative(-0.44f, 4.8f)
+                    lineToRelative(-0.12f, -2.59f)
+                    lineToRelative(2.59f, -0.12f)
+                    lineToRelative(0.12f, 2.59f)
+                    close()
+                }
+            }
+        }.build()
+        return _ghostScrollCrossPointingLight!!
+    }
+
+private var _ghostScrollCrossPointingLight: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box {
+        Image(
+            imageVector = AppIllus.GhostScrollCrossPointingLight,
+            contentDescription = null,
+            modifier = Modifier.size(AppImages.previewSize)
+        )
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/navigation/NavigationDestination.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/navigation/NavigationDestination.kt
@@ -116,12 +116,13 @@ sealed class NewTransferNavigation : NavigationDestination() {
     data object ImportFilesDestination : NewTransferNavigation()
 
     @Serializable
-    data class ValidateUserEmailDestination(val userEmail: String) : NewTransferNavigation()
+    data class ValidateUserEmailDestination(val authorEmail: String) : NewTransferNavigation()
 
     @Serializable
     data class UploadProgressDestination(
         val transferType: TransferTypeUi,
         val totalSize: Long,
+        val authorEmail: String?,
     ) : NewTransferNavigation()
 
     @Serializable
@@ -135,7 +136,11 @@ sealed class NewTransferNavigation : NavigationDestination() {
     data class UploadErrorDestination(
         val transferType: TransferTypeUi,
         val totalSize: Long,
+        val authorEmail: String?,
     ) : NewTransferNavigation()
+
+    @Serializable
+    data object UploadIntegrityErrorDestination : NewTransferNavigation()
 
     @Serializable
     data object NewTransferFilesDetailsDestination : NewTransferNavigation()

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
@@ -175,6 +175,14 @@ class ImportFilesViewModel @Inject constructor(
         }
     }
 
+    fun startLoadingSendButton() {
+        _sendButtonStatus.value = SendButtonStatus.Loading
+    }
+
+    fun resetSendButtonStatus() {
+        _sendButtonStatus.value = SendButtonStatus.Clickable
+    }
+
     fun importFiles(uris: List<Uri>) {
         viewModelScope.launch(ioDispatcher) {
             importUris(uris)

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
@@ -70,13 +70,6 @@ class ImportFilesViewModel @Inject constructor(
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
-    val sendStatus by transferSendManager::sendStatus
-
-    // val hasOngoingUploadSession = uploadManager
-    //     .lastUploadFlow
-    //     .map { it != null }
-    //     .stateIn(viewModelScope, SharingStarted.Eagerly, false)
-
     val lastUpload = uploadManager.lastUploadFlow
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
@@ -66,11 +66,10 @@ class ImportFilesViewModel @Inject constructor(
     private val importationFilesManager: ImportationFilesManager,
     private val newTransferOpenManager: NewTransferOpenManager,
     private val uploadManager: UploadManager,
-    private val transferSendManager: TransferSendManager,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
-    val lastUpload = uploadManager.lastUploadFlow
+    val lastUploadSession = uploadManager.lastUploadFlow
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     val filesDetailsUiState = importationFilesManager.importedFiles.map {
@@ -178,10 +177,6 @@ class ImportFilesViewModel @Inject constructor(
             appSettingsManager.setLastAuthorEmail(newUploadSession.authorEmail)
             uploadManager.createAndGetUpload(newUploadSession)
         }
-    }
-
-    fun resetSendActionResult() {
-        transferSendManager.resetSendStatus()
     }
 
     private suspend fun removeOldData() {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/ImportFilesViewModel.kt
@@ -72,6 +72,14 @@ class ImportFilesViewModel @Inject constructor(
 
     val sendStatus by transferSendManager::sendStatus
 
+    // val hasOngoingUploadSession = uploadManager
+    //     .lastUploadFlow
+    //     .map { it != null }
+    //     .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    val lastUpload = uploadManager.lastUploadFlow
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
     val filesDetailsUiState = importationFilesManager.importedFiles.map {
         when {
             it.isEmpty() -> FilesDetailsUiState.EmptyFiles
@@ -169,13 +177,13 @@ class ImportFilesViewModel @Inject constructor(
         }
     }
 
-    fun sendTransfer() {
-        viewModelScope.launch(ioDispatcher) {
+    // Creating the new upload session will trigger the navigation from the ImportFilesScreen to the UploadProgressScreen which
+    // will start the transfer and the worker.
+    fun createNewUploadSession() {
+        viewModelScope.launch {
             val newUploadSession = generateNewUploadSession()
-
             appSettingsManager.setLastAuthorEmail(newUploadSession.authorEmail)
-
-            transferSendManager.sendNewTransfer(newUploadSession)
+            uploadManager.createAndGetUpload(newUploadSession)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferNavHost.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferNavHost.kt
@@ -31,6 +31,7 @@ import com.infomaniak.swisstransfer.ui.screen.newtransfer.importfiles.AutoResetT
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.importfiles.ImportFilesScreen
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.importfiles.components.TransferTypeUi
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.upload.UploadErrorScreen
+import com.infomaniak.swisstransfer.ui.screen.newtransfer.upload.UploadIntegrityErrorScreen
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.upload.UploadProgressScreen
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.upload.UploadSuccessScreen
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.validateemail.ValidateUserEmailScreen
@@ -54,10 +55,9 @@ fun NewTransferNavHost(
             ImportFilesScreen(
                 importFilesViewModel = hiltViewModel<ImportFilesViewModel>(it),
                 closeActivity = { closeActivity(false) },
-                navigateToUploadProgress = { transferType, totalSize ->
-                    navController.navigate(UploadProgressDestination(transferType, totalSize))
+                navigateToUploadProgress = { transferType, totalSize, authorEmail ->
+                    navController.navigate(UploadProgressDestination(transferType, totalSize, authorEmail))
                 },
-                navigateToEmailValidation = { email -> navController.navigate(ValidateUserEmailDestination(email)) },
                 navigateToFilesDetails = { navController.navigate(NewTransferFilesDetailsDestination) },
             )
         }
@@ -67,9 +67,9 @@ fun NewTransferNavHost(
                 closeActivity = closeActivityAndPromptForValidation,
                 navigateBack = { navController.navigateUp() },
                 navigateToUploadInProgress = { totalSize ->
-                    navController.navigate(UploadProgressDestination(TransferTypeUi.Mail, totalSize))
+                    navController.navigate(UploadProgressDestination(TransferTypeUi.Mail, totalSize, args.authorEmail))
                 },
-                emailToValidate = args.userEmail,
+                emailToValidate = args.authorEmail,
             )
         }
         composable<UploadProgressDestination> {
@@ -79,7 +79,11 @@ fun NewTransferNavHost(
                 navigateToUploadSuccess = { transferUuid, transferUrl ->
                     navController.navigate(UploadSuccessDestination(args.transferType, transferUuid, transferUrl))
                 },
-                navigateToUploadError = { navController.navigate(UploadErrorDestination(args.transferType, args.totalSize)) },
+                navigateToUploadError = {
+                    navController.navigate(UploadErrorDestination(args.transferType, args.totalSize, args.authorEmail))
+                },
+                navigateToEmailValidation = { navController.navigateToEmailValidation(args) },
+                navigateToAppIntegrityError = { navController.navigate(UploadIntegrityErrorDestination) },
                 navigateBackToImportFiles = { navController.popBackStack(route = ImportFilesDestination, inclusive = false) },
                 // Called instead of `navigateBackToImportFiles()` when the app has been killed while uploading
                 closeActivity = { closeActivity(false) },
@@ -101,11 +105,11 @@ fun NewTransferNavHost(
             UploadErrorScreen(
                 navigateBackToUploadProgress = {
                     val hasPoppedBack = navController.popBackStack(
-                        route = UploadProgressDestination(args.transferType, args.totalSize),
+                        route = UploadProgressDestination(args.transferType, args.totalSize, args.authorEmail),
                         inclusive = false,
                     )
                     if (!hasPoppedBack) {
-                        navController.navigate(UploadProgressDestination(args.transferType, args.totalSize))
+                        navController.navigate(UploadProgressDestination(args.transferType, args.totalSize, args.authorEmail))
                         Sentry.captureMessage(
                             "PopBackStack to retry transfer after error has failed",
                             SentryLevel.ERROR,
@@ -120,6 +124,9 @@ fun NewTransferNavHost(
                 closeActivity = { closeActivity(true) },
             )
         }
+        composable<UploadIntegrityErrorDestination> {
+            UploadIntegrityErrorScreen(closeActivity = { closeActivity(false) })
+        }
         composable<NewTransferFilesDetailsDestination> {
             val backStackEntry = remember(it) { navController.getBackStackEntry(ImportFilesDestination) }
             NewTransferFilesDetailsScreen(
@@ -130,5 +137,16 @@ fun NewTransferNavHost(
                 navigateBack = { navController.navigateUp() },
             )
         }
+    }
+}
+
+private fun NavHostController.navigateToEmailValidation(args: UploadProgressDestination) {
+    args.authorEmail?.let { userEmail ->
+        navigate(ValidateUserEmailDestination(userEmail))
+    } ?: run {
+        Sentry.captureMessage(
+            "Tried navigating to email validation but we received no email to validate",
+            SentryLevel.WARNING,
+        )
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferNavHost.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/NewTransferNavHost.kt
@@ -65,7 +65,7 @@ fun NewTransferNavHost(
             val args = it.toRoute<ValidateUserEmailDestination>()
             ValidateUserEmailScreen(
                 closeActivity = closeActivityAndPromptForValidation,
-                navigateBack = { navController.navigateUp() },
+                navigateBackToFileImportation = { navController.popBackStack(ImportFilesDestination, false) },
                 navigateToUploadInProgress = { totalSize ->
                     navController.navigate(UploadProgressDestination(TransferTypeUi.Mail, totalSize, args.authorEmail))
                 },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/SendButtonStatus.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/SendButtonStatus.kt
@@ -24,5 +24,6 @@ sealed interface SendButtonStatus {
     // This status usually only lasts for a split seconds if the user doesn't pick multiple hundred of files. So this prevents the
     // button from being clicked but doesn't show a jarring blinking button to the user.
     data object Unclickable : SendButtonStatus
+    data object Loading : SendButtonStatus
     data class Progress(@FloatRange(0.0, 1.0) val progress: Float) : SendButtonStatus
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferSendManager.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/TransferSendManager.kt
@@ -48,27 +48,7 @@ class TransferSendManager @Inject constructor(
     private val _sendStatus = MutableStateFlow<SendStatus>(SendStatus.Initial)
     val sendStatus = _sendStatus.asStateFlow()
 
-    // suspend fun sendNewTransfer(newUploadSession: UploadSession) {
-    //     runCatching {
-    //         // When clicking the "Send" button, a new session is created.
-    //         // If there is an error before reaching the UploadProgressScreen, we stay in ImportFilesScreen.
-    //         // Every time we'll click the "Send" button again, a new session will be created.
-    //         // So we'll have multiple UploadSession in Realm. We don't want that. We only want the last session.
-    //         // So before creating the new session, we need to remove the previous failed ones.
-    //         uploadManager.removeAllUploadSession()
-    //
-    //         val uploadSession = uploadManager.createAndGetUpload(newUploadSession)
-    //         sendTransfer(uploadSession)
-    //     }.onFailure { exception ->
-    //         if (exception !is NetworkException && exception !is KmpNetworkException) {
-    //             SentryLog.e(TAG, "Failure on sendNewTransfer", exception)
-    //         }
-    //         _sendStatus.update { SendStatus.Failure }
-    //     }
-    // }
-
-    // TODO: Rename
-    suspend fun resendLastTransfer() {
+    suspend fun sendLastTransfer() {
         val uploadSession = uploadManager.getLastUpload() ?: run {
             SentryLog.e(TAG, "No last upload found")
             return

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -93,7 +93,7 @@ fun ImportFilesScreen(
     val passwordOptionState by importFilesViewModel.selectedPasswordOption.collectAsStateWithLifecycle()
     val emailLanguageState by importFilesViewModel.selectedLanguageOption.collectAsStateWithLifecycle()
 
-    val lastUpload by importFilesViewModel.lastUpload.collectAsStateWithLifecycle()
+    val lastUploadSession by importFilesViewModel.lastUploadSession.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
 
@@ -119,9 +119,9 @@ fun ImportFilesScreen(
     HandleStartupFilePick(importFilesViewModel.openFilePickerEvent, ::pickFiles)
 
     HandleNavigationToUploadInProgress(
-        lastUpload = { lastUpload },
+        lastUploadSession = { lastUploadSession },
         navigateToUploadProgress = { totalSize ->
-            navigateToUploadProgress(selectedTransferType, totalSize, lastUpload?.authorEmail)
+            navigateToUploadProgress(selectedTransferType, totalSize, lastUploadSession?.authorEmail)
         }
     )
 
@@ -193,9 +193,9 @@ private fun HandleStartupFilePick(openFilePickerEvent: ReceiveChannel<Unit>, pic
 }
 
 @Composable
-fun HandleNavigationToUploadInProgress(lastUpload: () -> UploadSession?, navigateToUploadProgress: (Long) -> Unit) {
-    LaunchedEffect(lastUpload()) {
-        val uploadSession = lastUpload() ?: return@LaunchedEffect
+fun HandleNavigationToUploadInProgress(lastUploadSession: () -> UploadSession?, navigateToUploadProgress: (Long) -> Unit) {
+    LaunchedEffect(lastUploadSession()) {
+        val uploadSession = lastUploadSession() ?: return@LaunchedEffect
 
         navigateToUploadProgress(uploadSession.totalFileSize())
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -125,16 +125,6 @@ fun ImportFilesScreen(
         }
     )
 
-    // HandleSendActionResult(
-    //     snackbarHostState = snackbarHostState,
-    //     sendStatus = { sendStatus },
-    //     navigateToUploadProgress = { totalSize ->
-    //         navigateToUploadProgress(selectedTransferType, totalSize)
-    //     },
-    //     navigateToEmailValidation = { navigateToEmailValidation(emailTextFieldCallbacks.transferAuthorEmail.get()) },
-    //     resetSendActionResult = importFilesViewModel::resetSendActionResult,
-    // )
-
     val transferOptionsCallbacks = importFilesViewModel.getTransferOptionsCallbacks(
         transferOptionsStates = {
             buildList {
@@ -185,7 +175,7 @@ fun ImportFilesScreen(
         sendStatus = { SendStatus.Initial }, // TODO: Only used for button
         sendTransfer = {
             if (NotificationPermissionUtils.hasNotificationPermission(context)) {
-				importFilesViewModel.createNewUploadSession()
+                importFilesViewModel.createNewUploadSession()
             } else {
                 NotificationPermissionUtils.askNotificationPermission(launcher)
             }
@@ -210,46 +200,6 @@ fun HandleNavigationToUploadInProgress(lastUpload: () -> UploadSession?, navigat
         navigateToUploadProgress(uploadSession.totalFileSize())
     }
 }
-
-// @Composable
-// private fun HandleSendActionResult(
-//     snackbarHostState: SnackbarHostState,
-//     sendStatus: () -> SendStatus,
-//     navigateToUploadProgress: (totalSize: Long) -> Unit,
-//     navigateToEmailValidation: () -> Unit,
-//     resetSendActionResult: () -> Unit,
-// ) {
-//     val context = LocalContext.current
-//
-//     LaunchedEffect(sendStatus()) {
-//         when (val actionResult = sendStatus()) {
-//             is SendStatus.Success -> {
-//                 // If the user cancels the transfer while in UploadProgress, we're gonna popBackStack to ImportFiles.
-//                 // If we don't reset the ImportFiles state machine, we'll automatically navigate-back to UploadProgress again.
-//                 // So, before leaving ImportFiles to go to UploadProgress, we need to reset the ImportFiles state machine.
-//                 resetSendActionResult()
-//                 navigateToUploadProgress(actionResult.totalSize)
-//             }
-//             is SendStatus.NoNetwork -> {
-//                 snackbarHostState.showSnackbar(context.getString(R.string.networkUnavailable))
-//                 resetSendActionResult()
-//             }
-//             is SendStatus.Refused -> {
-//                 snackbarHostState.showSnackbar(context.getString(R.string.errorAppIntegrity))
-//                 resetSendActionResult()
-//             }
-//             is SendStatus.Failure -> {
-//                 snackbarHostState.showSnackbar(context.getString(R.string.errorUnknown))
-//                 resetSendActionResult()
-//             }
-//             is SendStatus.RequireEmailValidation -> {
-//                 navigateToEmailValidation()
-//                 resetSendActionResult()
-//             }
-//             else -> Unit
-//         }
-//     }
-// }
 
 @Composable
 private fun ImportFilesScreen(

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/importfiles/ImportFilesScreen.kt
@@ -447,10 +447,6 @@ private fun SendButtonStatus.canEnableButton(): Boolean = when (this) {
     SendButtonStatus.Loading -> false
 }
 
-enum class SendButtonStatus {
-    Available, Loading
-}
-
 data class EmailTextFieldCallbacks(
     val transferAuthorEmail: GetSetCallbacks<String>,
     val isAuthorEmailInvalid: () -> Boolean,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadIntegrityErrorScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadIntegrityErrorScreen.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak SwissTransfer - Android
- * Copyright (C) 2024 Infomaniak Network SA
+ * Copyright (C) 2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,72 +17,46 @@
  */
 package com.infomaniak.swisstransfer.ui.screen.newtransfer.upload
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import androidx.hilt.navigation.compose.hiltViewModel
 import com.infomaniak.swisstransfer.R
-import com.infomaniak.swisstransfer.ui.components.*
+import com.infomaniak.swisstransfer.ui.components.BottomStickyButtonScaffold
+import com.infomaniak.swisstransfer.ui.components.BrandTopAppBar
+import com.infomaniak.swisstransfer.ui.components.EmptyState
+import com.infomaniak.swisstransfer.ui.components.LargeButton
 import com.infomaniak.swisstransfer.ui.images.AppImages.AppIllus
 import com.infomaniak.swisstransfer.ui.images.illus.uploadError.GhostMagnifyingGlassQuestionMark
-import com.infomaniak.swisstransfer.ui.screen.newtransfer.importfiles.areTransferDataStillAvailable
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
-import com.infomaniak.core.R as RCore
 
 @Composable
-fun UploadErrorScreen(
-    navigateBackToUploadProgress: () -> Unit,
-    navigateBackToImportFiles: () -> Unit,
-    closeActivity: () -> Unit,
-    uploadProgressViewModel: UploadProgressViewModel = hiltViewModel<UploadProgressViewModel>(),
-) {
-
-    BackHandler(onBack = {})
-
+fun UploadIntegrityErrorScreen(closeActivity: () -> Unit) {
     BottomStickyButtonScaffold(
         topBar = { BrandTopAppBar() },
-        topButton = {
+        bottomButton = {
             LargeButton(
                 modifier = it,
-                title = stringResource(RCore.string.buttonRetry),
-                onClick = { navigateBackToUploadProgress() },
+                title = stringResource(R.string.contentDescriptionButtonClose),
+                onClick = { closeActivity() },
             )
-        },
-        bottomButton = {
-            if (areTransferDataStillAvailable) {
-                LargeButton(
-                    modifier = it,
-                    title = stringResource(R.string.buttonEditTransfer),
-                    style = ButtonType.Secondary,
-                    onClick = { uploadProgressViewModel.removeAllUploadSession(onCompletion = navigateBackToImportFiles) },
-                )
-            } else {
-                LargeButton(
-                    modifier = it,
-                    title = stringResource(R.string.buttonCancelTransfer),
-                    style = ButtonType.DestructiveText,
-                    onClick = { uploadProgressViewModel.removeAllUploadSession(onCompletion = closeActivity) },
-                )
-            }
         }
     ) {
         EmptyState(
             content = { Image(imageVector = AppIllus.GhostMagnifyingGlassQuestionMark.image(), contentDescription = null) },
             titleRes = R.string.uploadErrorTitle,
-            descriptionRes = R.string.uploadErrorDescription,
+            descriptionRes = R.string.errorAppIntegrity,
         )
     }
 }
 
 @PreviewAllWindows
 @Composable
-private fun UploadErrorScreenPreview() {
+private fun Preview() {
     SwissTransferTheme {
         Surface {
-            UploadErrorScreen({}, {}, {})
+            UploadIntegrityErrorScreen({})
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadIntegrityErrorScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadIntegrityErrorScreen.kt
@@ -28,7 +28,7 @@ import com.infomaniak.swisstransfer.ui.components.BrandTopAppBar
 import com.infomaniak.swisstransfer.ui.components.EmptyState
 import com.infomaniak.swisstransfer.ui.components.LargeButton
 import com.infomaniak.swisstransfer.ui.images.AppImages.AppIllus
-import com.infomaniak.swisstransfer.ui.images.illus.uploadError.GhostMagnifyingGlassQuestionMark
+import com.infomaniak.swisstransfer.ui.images.illus.appIntegrity.GhostScrollCrossPointing
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
 
@@ -47,7 +47,7 @@ fun UploadIntegrityErrorScreen(closeActivity: () -> Unit) {
         }
     ) {
         EmptyState(
-            content = { Image(imageVector = AppIllus.GhostMagnifyingGlassQuestionMark.image(), contentDescription = null) },
+            content = { Image(imageVector = AppIllus.GhostScrollCrossPointing.image(), contentDescription = null) },
             titleRes = R.string.uploadErrorTitle,
             descriptionRes = R.string.errorAppIntegrity,
         )

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadIntegrityErrorScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadIntegrityErrorScreen.kt
@@ -17,6 +17,7 @@
  */
 package com.infomaniak.swisstransfer.ui.screen.newtransfer.upload
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -33,6 +34,8 @@ import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
 
 @Composable
 fun UploadIntegrityErrorScreen(closeActivity: () -> Unit) {
+    BackHandler { closeActivity() }
+
     BottomStickyButtonScaffold(
         topBar = { BrandTopAppBar() },
         bottomButton = {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
@@ -81,7 +81,7 @@ fun UploadProgressScreen(
 
     LaunchedEffect(Unit) {
         uploadProgressViewModel.trackUploadProgress()
-        uploadProgressViewModel.sendNewTransfer()
+        uploadProgressViewModel.initNewTransfer()
     }
 
     HandleProgressState({ uiState }, navigateToUploadSuccess, navigateToUploadError, navigateBackToImportFiles, closeActivity)
@@ -120,15 +120,13 @@ fun HandleSendStatus(
                 // TODO: Do we need to check for this?
                 // navigateToUploadProgress(actionResult.totalSize)
             }
-            is SendStatus.NoNetwork -> {
-                // TODO: Handle this case. Check if snackbar code doesn't straight block the code execution
-                snackbarHostState.showSnackbar(context.getString(R.string.networkUnavailable))
-                resetSendStatus()
-            }
             is SendStatus.Refused -> {
                 navigateToAppIntegrityError()
                 resetSendStatus()
             }
+            // We are waiting to have access to the network before starting the app integrity and container step, so if we still
+            // get a NoNetwork during that step then it's fine to navigate to the error screen and let the user retry manually
+            is SendStatus.NoNetwork,
             is SendStatus.Failure -> {
                 navigateToUploadError()
                 resetSendStatus() // Needed apparently

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -102,20 +101,8 @@ fun HandleSendStatus(
     navigateToAppIntegrityError: () -> Unit,
     resetSendStatus: () -> Unit,
 ) {
-    val context = LocalContext.current
-
     LaunchedEffect(sendStatus()) {
-        when (val actionResult = sendStatus()) {
-            is SendStatus.Success -> {
-                // TODO: Did we still need to reset?
-                // // If the user cancels the transfer while in UploadProgress, we're gonna popBackStack to ImportFiles.
-                // // If we don't reset the ImportFiles state machine, we'll automatically navigate-back to UploadProgress again.
-                // // So, before leaving ImportFiles to go to UploadProgress, we need to reset the ImportFiles state machine.
-                // resetSendActionResult()
-
-                // TODO: Do we need to check for this?
-                // navigateToUploadProgress(actionResult.totalSize)
-            }
+        when (sendStatus()) {
             is SendStatus.Refused -> {
                 navigateToAppIntegrityError()
                 resetSendStatus()
@@ -131,7 +118,9 @@ fun HandleSendStatus(
                 navigateToEmailValidation()
                 // resetSendActionResult() // Not needed apparently
             }
-            else -> Unit
+            SendStatus.Initial,
+            SendStatus.Pending,
+            is SendStatus.Success -> Unit
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalTextStyle
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -66,12 +65,10 @@ fun UploadProgressScreen(
 
     val adScreenType = rememberSaveable { UploadProgressAdType.entries.random() }
     var showBottomSheet by rememberSaveable { mutableStateOf(false) }
-    val snackbarHostState = remember { SnackbarHostState() }
 
     BackHandler(enabled = !showBottomSheet, onBack = { showBottomSheet = true })
 
     HandleSendStatus(
-        snackbarHostState = snackbarHostState,
         sendStatus = { sendStatus },
         navigateToUploadError = { navigateToUploadError() },
         navigateToEmailValidation = { navigateToEmailValidation() },
@@ -99,7 +96,6 @@ fun UploadProgressScreen(
 
 @Composable
 fun HandleSendStatus(
-    snackbarHostState: SnackbarHostState,
     sendStatus: () -> SendStatus,
     navigateToUploadError: () -> Unit,
     navigateToEmailValidation: () -> Unit,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
@@ -77,7 +77,7 @@ fun UploadProgressScreen(
 
     LaunchedEffect(Unit) {
         uploadProgressViewModel.trackUploadProgress()
-        uploadProgressViewModel.initNewTransfer()
+        uploadProgressViewModel.initializeLastTransfer()
     }
 
     HandleProgressState({ uiState }, navigateToUploadSuccess, navigateToUploadError, navigateBackToImportFiles, closeActivity)

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
@@ -112,12 +112,9 @@ fun HandleSendStatus(
             is SendStatus.NoNetwork,
             is SendStatus.Failure -> {
                 navigateToUploadError()
-                resetSendStatus() // Needed apparently
+                resetSendStatus()
             }
-            is SendStatus.RequireEmailValidation -> {
-                navigateToEmailValidation()
-                // resetSendActionResult() // Not needed apparently
-            }
+            is SendStatus.RequireEmailValidation -> navigateToEmailValidation()
             SendStatus.Initial,
             SendStatus.Pending,
             is SendStatus.Success -> Unit

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressScreen.kt
@@ -87,9 +87,9 @@ fun UploadProgressScreen(
         sendStatus = { sendStatus },
         isNetworkAvailable = { isNetworkAvailable },
         totalSizeInBytes = totalSizeInBytes,
-        showBottomSheet = GetSetCallbacks(get = { showBottomSheet }, set = { showBottomSheet = it }),
         adScreenType = adScreenType,
-        onCancel = { uploadProgressViewModel.cancelUpload(onFailedCancellation = closeActivity) }
+        onCancel = { uploadProgressViewModel.cancelUpload(onFailedCancellation = closeActivity) },
+        showBottomSheet = GetSetCallbacks(get = { showBottomSheet }, set = { showBottomSheet = it }),
     )
 }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressViewModel.kt
@@ -115,7 +115,7 @@ class UploadProgressViewModel @Inject constructor(
         }
     }
 
-    fun initNewTransfer() {
+    fun initializeLastTransfer() {
         viewModelScope.launch {
             if (uploadWorkerScheduler.hasAlreadyBeenScheduled()) return@launch
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressViewModel.kt
@@ -18,6 +18,7 @@
 package com.infomaniak.swisstransfer.ui.screen.newtransfer.upload
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.infomaniak.core.network.NetworkAvailability
@@ -42,6 +43,8 @@ class UploadProgressViewModel @Inject constructor(
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
+
+    val sendStatus by transferSendManager::sendStatus
 
     val isNetworkAvailable = NetworkAvailability(appContext).isNetworkAvailable
         .onEach { SentryLog.d("Internet availability", if (it) "Available" else "Unavailable") }
@@ -103,11 +106,15 @@ class UploadProgressViewModel @Inject constructor(
         }
     }
 
-    fun resendLastTransfer(onCompletion: () -> Unit) {
-        viewModelScope.launch(ioDispatcher) {
+    fun sendNewTransfer() {
+        Log.e("gibran", "sendNewTransfer: SENDING A NEW TRANSFER FROM THE UPLOAD PROGRESS VIEW MODEL", );
+        viewModelScope.launch {
             transferSendManager.resendLastTransfer()
-            withContext(mainDispatcher) { onCompletion() }
         }
+    }
+
+    fun resetSendStatus() {
+        transferSendManager.resetSendStatus()
     }
 
     companion object {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressViewModel.kt
@@ -131,7 +131,7 @@ class UploadProgressViewModel @Inject constructor(
                 if (isNetworkAvailable) {
                     SentryLog.i(TAG, "Initializing the upload")
                     hasAlreadyInitialized = true
-                    transferSendManager.resendLastTransfer()
+                    transferSendManager.sendLastTransfer()
                 }
             }
         }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressViewModel.kt
@@ -97,7 +97,9 @@ class UploadProgressViewModel @Inject constructor(
                 if (uploadSession == null) {
                     uploadManager.removeAllUploadSession()
                 } else {
-                    uploadManager.cancelUploadSession(uploadSession.uuid)
+                    // We can cancel during the app integrity check, before any remote container creation. In this case, no need
+                    // to cancel any remote upload session.
+                    if (uploadSession.remoteContainer != null) uploadManager.cancelUploadSession(uploadSession.uuid)
                 }
             }.onFailure { exception ->
                 if (exception is CancellationException) throw exception

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressViewModel.kt
@@ -55,7 +55,7 @@ class UploadProgressViewModel @Inject constructor(
 
     // This stateflow is required in order to start with `initialValue = false`. We need it to block the initialization of the
     // upload while we wait for a network connection. If we start with `initialValue = true`, the initialization will go through
-    // because of to the initial value.
+    // because of the initial value.
     private val uploadInitializationIsNetworkAvailable = NetworkAvailability(appContext).isNetworkAvailable
         .stateIn(
             scope = viewModelScope,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadProgressViewModel.kt
@@ -121,12 +121,10 @@ class UploadProgressViewModel @Inject constructor(
         viewModelScope.launch {
             if (uploadWorkerScheduler.hasAlreadyBeenScheduled()) return@launch
 
-            uploadInitializationIsNetworkAvailable.collect { isNetworkAvailable ->
-                if (isNetworkAvailable) {
-                    SentryLog.i(TAG, "Initializing the upload")
-                    transferSendManager.sendLastTransfer()
-                }
-            }
+            uploadInitializationIsNetworkAvailable.first { isNetworkAvailable -> isNetworkAvailable }
+
+            SentryLog.i(TAG, "Initializing the upload")
+            transferSendManager.sendLastTransfer()
         }
     }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/components/Progress.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/components/Progress.kt
@@ -22,7 +22,10 @@ import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.infomaniak.core.percent
@@ -37,15 +40,12 @@ fun Progress(
     totalSizeInBytes: Long,
     modifier: Modifier = Modifier,
 ) {
-    val style = SwissTransferTheme.typography.labelRegular.copy(color = SwissTransferTheme.colors.secondaryTextColor)
-    CompositionLocalProvider(value = LocalTextStyle provides style) {
-        Row(modifier) {
-            Percentage({ progressState().uploadedSize }, totalSizeInBytes)
-            Text(text = " - ")
-            UploadedSize { progressState().uploadedSize }
-            Text(text = " / ")
-            TotalSize(totalSizeInBytes)
-        }
+    Row(modifier) {
+        Percentage({ progressState().uploadedSize }, totalSizeInBytes)
+        Text(text = " - ")
+        UploadedSize { progressState().uploadedSize }
+        Text(text = " / ")
+        TotalSize(totalSizeInBytes)
     }
 }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/validateemail/ValidateUserEmailScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/validateemail/ValidateUserEmailScreen.kt
@@ -78,7 +78,7 @@ fun ValidateUserEmailScreen(
 
     fun removeUploadSessionAndBack() {
         scope.launch {
-            validateUserEmailViewModel.removeUploadSession()
+            validateUserEmailViewModel.removeAllUploadSession()
             navigateBackToFileImportation()
         }
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/validateemail/ValidateUserEmailScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/validateemail/ValidateUserEmailScreen.kt
@@ -17,6 +17,7 @@
  */
 package com.infomaniak.swisstransfer.ui.screen.newtransfer.validateemail
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -60,7 +61,7 @@ private val MAX_LAYOUT_WIDTH = 400.dp
 @Composable
 fun ValidateUserEmailScreen(
     closeActivity: () -> Unit,
-    navigateBack: () -> Unit,
+    navigateBackToFileImportation: () -> Unit,
     navigateToUploadInProgress: (totalSize: Long) -> Unit,
     emailToValidate: String,
     validateUserEmailViewModel: ValidateUserEmailViewModel = hiltViewModel<ValidateUserEmailViewModel>(),
@@ -75,6 +76,15 @@ fun ValidateUserEmailScreen(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
+    fun removeUploadSessionAndBack() {
+        scope.launch {
+            validateUserEmailViewModel.removeUploadSession()
+            navigateBackToFileImportation()
+        }
+    }
+
+    BackHandler { removeUploadSessionAndBack() }
+
     HandleValidationStatus({ sendStatus }, navigateToUploadInProgress, snackbarHostState)
 
     HandleUnknownValidationError({ uiState }, snackbarHostState)
@@ -88,7 +98,7 @@ fun ValidateUserEmailScreen(
         isLoading = { isLoading },
         isInvalidVerificationCode = { isInvalidVerificationCode },
         snackbarHostState = snackbarHostState,
-        navigateBack = navigateBack,
+        navigateBack = ::removeUploadSessionAndBack,
         closeActivity = closeActivity,
         onResendEmailCode = {
             scope.launch {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/validateemail/ValidateUserEmailViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/validateemail/ValidateUserEmailViewModel.kt
@@ -69,7 +69,7 @@ class ValidateUserEmailViewModel @Inject constructor(
         }
     }
 
-    suspend fun removeUploadSession() {
+    suspend fun removeAllUploadSession() {
         uploadManager.removeAllUploadSession()
     }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/validateemail/ValidateUserEmailViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/validateemail/ValidateUserEmailViewModel.kt
@@ -69,6 +69,10 @@ class ValidateUserEmailViewModel @Inject constructor(
         }
     }
 
+    suspend fun removeUploadSession() {
+        uploadManager.removeAllUploadSession()
+    }
+
     enum class ValidateEmailUiState {
         Default, Loading, InvalidVerificationCode, UnknownError, NoNetwork
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/validateemail/ValidateUserEmailViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/validateemail/ValidateUserEmailViewModel.kt
@@ -54,7 +54,7 @@ class ValidateUserEmailViewModel @Inject constructor(
                 }
             }.onSuccess { token ->
                 uploadManager.updateAuthorEmailToken(email, token.token)
-                transferSendManager.resendLastTransfer()
+                transferSendManager.sendLastTransfer()
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/utils/UploadSessionExt.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/utils/UploadSessionExt.kt
@@ -15,13 +15,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.infomaniak.swisstransfer.ui.navigation
+package com.infomaniak.swisstransfer.ui.utils
 
-const val NOTIFICATION_NAVIGATION_KEY = "notificationNavigationKey"
-const val TRANSFER_UUID_KEY = "transferUuidKey"
-const val TRANSFER_TYPE_KEY = "transferTypeKey"
-const val TRANSFER_TOTAL_SIZE_KEY = "transferTotalSizeKey"
-const val TRANSFER_URL_KEY = "transferUrlKey"
-const val TRANSFER_AUTHOR_EMAIL_KEY = "transferAuthorEmailKey"
+import com.infomaniak.multiplatform_swisstransfer.common.interfaces.upload.UploadSession
 
-enum class NotificationNavigation { UploadProgress, UploadSuccess, UploadFailure }
+fun UploadSession.totalFileSize(): Long = files.sumOf { it.size }

--- a/app/src/main/java/com/infomaniak/swisstransfer/workers/UploadWorker.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/workers/UploadWorker.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.mapLatest
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -256,6 +257,15 @@ class UploadWorker @AssistedInject constructor(
                     else -> UploadProgressUiState.Default(lastUploadedSize)
                 } ?: UploadProgressUiState.Error(lastUploadedSize)
             }.filterNotNull()
+        }
+
+        suspend fun hasAlreadyBeenScheduled(): Boolean {
+            val workQuery = WorkQuery.Builder.fromUniqueWorkNames(listOf(TAG))
+                .addStates(listOf(State.BLOCKED, State.ENQUEUED, State.RUNNING))
+                .build()
+
+            val workInfo = workManager.getWorkInfosFlow(workQuery).first().firstOrNull()
+            return workInfo != null
         }
 
         fun cancelWork() {

--- a/app/src/main/java/com/infomaniak/swisstransfer/workers/UploadWorker.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/workers/UploadWorker.kt
@@ -41,6 +41,7 @@ import com.infomaniak.swisstransfer.ui.screen.newtransfer.importfiles.components
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.importfiles.components.TransferTypeUi.Companion.toTransferTypeUi
 import com.infomaniak.swisstransfer.ui.utils.HumanReadableSizeUtils
 import com.infomaniak.swisstransfer.ui.utils.NotificationsUtils
+import com.infomaniak.swisstransfer.ui.utils.totalFileSize
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CompletableDeferred
@@ -93,7 +94,7 @@ class UploadWorker @AssistedInject constructor(
         val uploadSession = uploadManager.getLastUpload() ?: return Result.failure()
         uploadSessionJob.complete(uploadSession)
 
-        val totalSize = uploadSession.files.sumOf { it.size }
+        val totalSize = uploadSession.totalFileSize()
 
         SentryLog.d(TAG, "Work started with ${uploadSession.files.count()} files of $totalSize bytes")
 
@@ -102,7 +103,7 @@ class UploadWorker @AssistedInject constructor(
             uploadSession.files.forEach { fileSession ->
                 uploadFileTask.start(fileSession, uploadSession) { bytesSent ->
                     uploadedBytes += bytesSent
-                    emitProgress(totalSize)
+                    emitProgress(totalSize, uploadSession.authorEmail)
                 }
             }
 
@@ -124,7 +125,7 @@ class UploadWorker @AssistedInject constructor(
                 is CancellationException -> Result.failure()
                 else -> {
                     SentryLog.e(TAG, "UploadWorker result FAILURE", exception)
-                    displayFailureNotification(totalSize)
+                    displayFailureNotification(totalSize, uploadSession.authorEmail)
                     Result.failure()
                 }
             }
@@ -135,29 +136,28 @@ class UploadWorker @AssistedInject constructor(
         SentryLog.i(TAG, "Work finished")
     }
 
-    private suspend fun emitProgress(totalSize: Long) {
+    private suspend fun emitProgress(totalSize: Long, authorEmail: String) {
         val currentTime = System.currentTimeMillis()
         if (currentTime - lastUpdateTime > PROGRESS_ELAPSED_TIME) {
             setProgress(workDataOf(UPLOADED_BYTES_TAG to uploadedBytes))
             lastUpdateTime = currentTime
-            displayProgressNotification(totalSize)
+            displayProgressNotification(totalSize, authorEmail)
         }
     }
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
 
         val uploadSession = uploadSessionJob.await()
-        val totalSize = uploadSession.files.sumOf { it.size }
         val builder = notificationsUtils.buildUploadNotification(
             requestCode = serviceNotificationId,
-            intent = createProgressNotificationIntent(totalSize),
+            intent = createProgressNotificationIntent(uploadSession.totalFileSize(), uploadSession.authorEmail),
             title = applicationContext.getString(R.string.uploadProgressIndication),
         )
 
         return ForegroundInfo(serviceNotificationId, builder.build())
     }
 
-    private suspend fun displayProgressNotification(totalSize: Long) {
+    private suspend fun displayProgressNotification(totalSize: Long, authorEmail: String) {
 
         val percent = percent(uploadedBytes, totalSize)
         val current = HumanReadableSizeUtils.getHumanReadableSize(applicationContext, uploadedBytes)
@@ -165,7 +165,7 @@ class UploadWorker @AssistedInject constructor(
 
         val builder = notificationsUtils.buildUploadNotification(
             requestCode = serviceNotificationId,
-            intent = createProgressNotificationIntent(totalSize),
+            intent = createProgressNotificationIntent(totalSize, authorEmail),
             title = applicationContext.getString(R.string.notificationUploadProgressTitle, percent),
             description = "$current / $total",
         )
@@ -179,11 +179,12 @@ class UploadWorker @AssistedInject constructor(
         setForeground(foregroundInfo)
     }
 
-    private fun createProgressNotificationIntent(totalSize: Long): Intent {
+    private fun createProgressNotificationIntent(totalSize: Long, authorEmail: String): Intent {
         return Intent(applicationContext, NewTransferActivity::class.java)
             .setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
             .putExtra(NOTIFICATION_NAVIGATION_KEY, NotificationNavigation.UploadProgress.name)
             .putExtra(TRANSFER_TYPE_KEY, transferType.name)
+            .putExtra(TRANSFER_AUTHOR_EMAIL_KEY, authorEmail)
             .putExtra(TRANSFER_TOTAL_SIZE_KEY, totalSize)
     }
 
@@ -209,13 +210,14 @@ class UploadWorker @AssistedInject constructor(
         )
     }
 
-    private fun displayFailureNotification(totalSize: Long) {
+    private fun displayFailureNotification(totalSize: Long, authorEmail: String) {
         notificationsUtils.sendUploadNotification(
             notificationId = NOTIFICATION_ID,
             intent = Intent(applicationContext, NewTransferActivity::class.java)
                 .setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
                 .putExtra(NOTIFICATION_NAVIGATION_KEY, NotificationNavigation.UploadFailure.name)
                 .putExtra(TRANSFER_TYPE_KEY, transferType.name)
+                .putExtra(TRANSFER_AUTHOR_EMAIL_KEY, authorEmail)
                 .putExtra(TRANSFER_TOTAL_SIZE_KEY, totalSize),
             title = applicationContext.getString(R.string.notificationUploadFailureTitle),
             description = applicationContext.getString(R.string.notificationUploadFailureDescription),

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -153,7 +153,7 @@
     <string name="transferExpiredDateReachedDescription">Tut mir leid, diese Übertragung ist am %s abgelaufen. Du kannst die Dateien nicht mehr herunterladen oder ansehen.</string>
     <string name="transferExpiredLimitReachedDescription">Entschuldigung, diese Übertragung hat die Grenze der %d möglichen Downloads erreicht.</string>
     <string name="transferExpiredTitle">Diese Übertragung ist nicht mehr verfügbar</string>
-    <string name="transferInitializing">Initialisierung…</string>
+    <string name="transferInitializing">Laden…</string>
     <string name="transferListSectionFuture">Zukunft</string>
     <string name="transferListSectionLastWeek">Letzte Woche</string>
     <string name="transferListSectionThisMonth">Diesen Monat</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -153,6 +153,7 @@
     <string name="transferExpiredDateReachedDescription">Tut mir leid, diese Übertragung ist am %s abgelaufen. Du kannst die Dateien nicht mehr herunterladen oder ansehen.</string>
     <string name="transferExpiredLimitReachedDescription">Entschuldigung, diese Übertragung hat die Grenze der %d möglichen Downloads erreicht.</string>
     <string name="transferExpiredTitle">Diese Übertragung ist nicht mehr verfügbar</string>
+    <string name="transferInitializing">Initialisierung…</string>
     <string name="transferListSectionFuture">Zukunft</string>
     <string name="transferListSectionLastWeek">Letzte Woche</string>
     <string name="transferListSectionThisMonth">Diesen Monat</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -153,6 +153,7 @@
     <string name="transferExpiredDateReachedDescription">Lo sentimos, esta transferencia expiró el %s. Ya no puede descargar ni ver los archivos.</string>
     <string name="transferExpiredLimitReachedDescription">Lo sentimos, esta transferencia ha alcanzado el límite de %d descargas posibles.</string>
     <string name="transferExpiredTitle">Esta transferencia ya no está disponible</string>
+    <string name="transferInitializing">Inicializando…</string>
     <string name="transferListSectionFuture">Futuro</string>
     <string name="transferListSectionLastWeek">La semana pasada</string>
     <string name="transferListSectionThisMonth">Este mes</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -153,7 +153,7 @@
     <string name="transferExpiredDateReachedDescription">Lo sentimos, esta transferencia expiró el %s. Ya no puede descargar ni ver los archivos.</string>
     <string name="transferExpiredLimitReachedDescription">Lo sentimos, esta transferencia ha alcanzado el límite de %d descargas posibles.</string>
     <string name="transferExpiredTitle">Esta transferencia ya no está disponible</string>
-    <string name="transferInitializing">Inicializando…</string>
+    <string name="transferInitializing">Cargando…</string>
     <string name="transferListSectionFuture">Futuro</string>
     <string name="transferListSectionLastWeek">La semana pasada</string>
     <string name="transferListSectionThisMonth">Este mes</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -154,7 +154,7 @@
     <string name="transferExpiredDateReachedDescription">Désolé, ce transfert a expiré le %s. Tu ne peux plus télécharger ni consulter les fichiers.</string>
     <string name="transferExpiredLimitReachedDescription">Désolé, ce transfert a atteint la limite de %d téléchargements possibles.</string>
     <string name="transferExpiredTitle">Ce transfert n’est plus disponible</string>
-    <string name="transferInitializing">Initialisation…</string>
+    <string name="transferInitializing">Chargement…</string>
     <string name="transferListSectionFuture">Futur</string>
     <string name="transferListSectionLastWeek">La semaine dernière</string>
     <string name="transferListSectionThisMonth">Ce mois-ci</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -154,6 +154,7 @@
     <string name="transferExpiredDateReachedDescription">Désolé, ce transfert a expiré le %s. Tu ne peux plus télécharger ni consulter les fichiers.</string>
     <string name="transferExpiredLimitReachedDescription">Désolé, ce transfert a atteint la limite de %d téléchargements possibles.</string>
     <string name="transferExpiredTitle">Ce transfert n’est plus disponible</string>
+    <string name="transferInitializing">Initialisation…</string>
     <string name="transferListSectionFuture">Futur</string>
     <string name="transferListSectionLastWeek">La semaine dernière</string>
     <string name="transferListSectionThisMonth">Ce mois-ci</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -153,6 +153,7 @@
     <string name="transferExpiredDateReachedDescription">Spiacente, questo trasferimento è scaduto il %s. Non è più possibile scaricare o visualizzare i file.</string>
     <string name="transferExpiredLimitReachedDescription">Spiacente, questo trasferimento ha raggiunto il limite di %d download possibili.</string>
     <string name="transferExpiredTitle">Questo trasferimento non è più disponibile</string>
+    <string name="transferInitializing">Inizializzazione…</string>
     <string name="transferListSectionFuture">Futuro</string>
     <string name="transferListSectionLastWeek">La scorsa settimana</string>
     <string name="transferListSectionThisMonth">Questo mese</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -153,7 +153,7 @@
     <string name="transferExpiredDateReachedDescription">Spiacente, questo trasferimento è scaduto il %s. Non è più possibile scaricare o visualizzare i file.</string>
     <string name="transferExpiredLimitReachedDescription">Spiacente, questo trasferimento ha raggiunto il limite di %d download possibili.</string>
     <string name="transferExpiredTitle">Questo trasferimento non è più disponibile</string>
-    <string name="transferInitializing">Inizializzazione…</string>
+    <string name="transferInitializing">Caricamento…</string>
     <string name="transferListSectionFuture">Futuro</string>
     <string name="transferListSectionLastWeek">La scorsa settimana</string>
     <string name="transferListSectionThisMonth">Questo mese</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,7 +158,7 @@
     <string name="transferExpiredDateReachedDescription">Sorry, this transfer expired on %s. You can no longer download or view the files.</string>
     <string name="transferExpiredLimitReachedDescription">Sorry, this transfer has reached the limit of %d possible downloads.</string>
     <string name="transferExpiredTitle">This transfer is no longer available</string>
-    <string name="transferInitializing">Initializing…</string>
+    <string name="transferInitializing">Loading…</string>
     <string name="transferListSectionFuture">Future</string>
     <string name="transferListSectionLastWeek">Last week</string>
     <string name="transferListSectionThisMonth">This month</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,6 +158,7 @@
     <string name="transferExpiredDateReachedDescription">Sorry, this transfer expired on %s. You can no longer download or view the files.</string>
     <string name="transferExpiredLimitReachedDescription">Sorry, this transfer has reached the limit of %d possible downloads.</string>
     <string name="transferExpiredTitle">This transfer is no longer available</string>
+    <string name="transferInitializing">Initializing…</string>
     <string name="transferListSectionFuture">Future</string>
     <string name="transferListSectionLastWeek">Last week</string>
     <string name="transferListSectionThisMonth">This month</string>


### PR DESCRIPTION
The idea is that the app integrity is now done while on the upload progress screen. This required to move all of the handling of success/errors of the app integrity and container creation from the `ImportFilesScreen` to the `UploadProgressScreen`.

The navigation has been modified to acomodate for the new order of screens. This implies amongst other things that `ValidateUserEmailDestination` is now accessible after `UploadProgressScreen` which required me to pass the `authorEmail` used by `ValidateUserEmailDestination` through `UploadProgressScreen`.

The sending of a transfer is now unified inside the same entry point `sendLastTransfer()` which fetches the last upload session from realm. The logic when sending a new transfer is the following: generate a new upload session, store it in realm, and then call `sendLastTransfer()`.

Is still missing: 
* The correct ~~illustration and~~ wording for the error screen when the integrity check fails (waiting on the spec to be ready)