### PR TITLE
fix: Add background for button describing the download status of a file and display the check icon when the file has been downloaded

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/TransferDownloadComposeUi.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/TransferDownloadComposeUi.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -195,14 +196,17 @@ class TransferDownloadComposeUi(
         enabled: Boolean = true,
     ) = IconButton(
         onClick = onClick,
-        modifier = modifier,
-        colors = IconButtonDefaults.iconButtonColors(contentColor = MaterialTheme.colorScheme.primary),
+        modifier = modifier.padding(4.dp),
+        colors = IconButtonDefaults.iconButtonColors(
+            contentColor = Color.White,
+            containerColor = SwissTransferTheme.colors.fileStatusButtonBackground,
+        ),
         enabled = enabled,
     ) {
         Icon(
             imageVector = icon,
             contentDescription = stringResource(labelResId),
-            modifier = Modifier.size(18.dp),
+            modifier = Modifier.size(16.dp),
         )
     }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/TransferDownloadComposeUi.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/TransferDownloadComposeUi.kt
@@ -164,10 +164,6 @@ class TransferDownloadComposeUi(
     fun CardCornerButton(modifier: Modifier = Modifier) {
         if (removalRequest.isAwaitingCall) {
             DownloadStatus { btnData, action, _ ->
-                if (action == openRequest && supportsPreview) {
-                    // Don't overlay the checkmark once the file is openable and has a preview.
-                    return@DownloadStatus
-                }
                 CardCornerButton(
                     icon = btnData.icon,
                     labelResId = btnData.labelResId,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/ColorDark.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/ColorDark.kt
@@ -75,6 +75,7 @@ val CustomDarkColorScheme = CustomColorScheme(
     tertiaryTextColor = Color(elephant),
     toolbarTextColor = Color(white),
     toolbarIconColor = Color(green_contrast),
+    fileStatusButtonBackground = Color(black_translucent),
     iconColor = Color(shark),
     navigationItemBackground = Color(dark2),
     tertiaryButtonBackground = Color(dark2),

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/ColorLight.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/ColorLight.kt
@@ -83,6 +83,7 @@ val CustomLightColorScheme = CustomColorScheme(
     tertiaryTextColor = Color(shark),
     toolbarTextColor = Color(white),
     toolbarIconColor = Color(green_contrast),
+    fileStatusButtonBackground = Color(black_translucent),
     iconColor = Color(elephant),
     navigationItemBackground = LightColorScheme.background,
     tertiaryButtonBackground = Color(rabbit),

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/Theme.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/theme/Theme.kt
@@ -93,6 +93,7 @@ data class CustomColorScheme(
     val swipeDefault: Color = Color.Unspecified,
     val swipeDelete: Color = Color.Unspecified,
     val swipeIcon: Color = Color.Unspecified,
+    val fileStatusButtonBackground: Color = Color.Unspecified,
 )
 
 private val Shapes = Shapes(


### PR DESCRIPTION
![check_and_download](https://github.com/user-attachments/assets/c865c254-2b65-464c-b18b-8a5f9cae6450)

![download_no_preview](https://github.com/user-attachments/assets/b7c3a75e-444c-436c-80e3-3a5310acead6)

![check](https://github.com/user-attachments/assets/f55267d8-8524-4323-98f9-0683adbcff60)
