### PR TITLE
fix: Forward Uri read permission from LaunchActivity to NewTransferActivity

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/LaunchActivity.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/LaunchActivity.kt
@@ -88,7 +88,7 @@ class LaunchActivity : ComponentActivity() {
             setClass(this@LaunchActivity, NewTransferActivity::class.java)
             // We need NewMessageActivity to have its standard launchMode in the Manifest
             // in order for FLAG_ACTIVITY_CLEAR_TOP to kill and recreate NewMessageActivity
-            setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }
     }
 


### PR DESCRIPTION
This will avoid the SecurityExceptions we're getting upon importing files that takes place after
the LaunchActivity is destroyed following
our call to finish().