### PR TITLE
fix: Display an error screen when coming from a deeplink and transfer is null

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/received/TransferExpiredDownloadCreditScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/received/TransferExpiredDownloadCreditScreen.kt
@@ -1,0 +1,68 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.swisstransfer.ui.screen.main.received
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.infomaniak.swisstransfer.R
+import com.infomaniak.swisstransfer.ui.components.BottomStickyButtonScaffold
+import com.infomaniak.swisstransfer.ui.components.BrandTopAppBar
+import com.infomaniak.swisstransfer.ui.components.EmptyState
+import com.infomaniak.swisstransfer.ui.components.LargeButton
+import com.infomaniak.swisstransfer.ui.images.AppImages.AppIllus
+import com.infomaniak.swisstransfer.ui.images.illus.mascotDead.MascotDead
+import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
+import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
+
+@Composable
+fun TransferExpiredDownloadCreditScreen(onCloseClicked: (() -> Unit)? = null) {
+    BottomStickyButtonScaffold(
+        topBar = { BrandTopAppBar() },
+        bottomButton = {
+            LargeButton(
+                modifier = it,
+                title = stringResource(R.string.contentDescriptionButtonClose),
+                onClick = { onCloseClicked?.invoke() },
+            )
+        },
+        modifier = Modifier.padding(WindowInsets.navigationBars.asPaddingValues()),
+    ) {
+        EmptyState(
+            content = { Image(imageVector = AppIllus.MascotDead.image(), contentDescription = null) },
+            title = stringResource(R.string.transferExpiredTitle),
+            description = stringResource(R.string.transferExpiredDescription),
+        )
+    }
+}
+
+@PreviewAllWindows
+@Composable
+private fun Preview() {
+    SwissTransferTheme {
+        Surface {
+            TransferExpiredDownloadCreditScreen(onCloseClicked = {})
+        }
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/TransferDetailsScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/TransferDetailsScreen.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak SwissTransfer - Android
- * Copyright (C) 2024 Infomaniak Network SA
+ * Copyright (C) 2024-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -56,12 +56,12 @@ import com.infomaniak.swisstransfer.ui.images.icons.QrCode
 import com.infomaniak.swisstransfer.ui.images.icons.Share
 import com.infomaniak.swisstransfer.ui.previewparameter.TransferUiListPreviewParameter
 import com.infomaniak.swisstransfer.ui.screen.main.components.SwissTransferScaffold
+import com.infomaniak.swisstransfer.ui.screen.main.received.TransferExpiredDownloadCreditScreen
 import com.infomaniak.swisstransfer.ui.screen.main.transferdetails.TransferDetailsViewModel.TransferDetailsUiState.Deleted
 import com.infomaniak.swisstransfer.ui.screen.main.transferdetails.TransferDetailsViewModel.TransferDetailsUiState.Success
 import com.infomaniak.swisstransfer.ui.screen.main.transferdetails.components.PasswordBottomSheet
 import com.infomaniak.swisstransfer.ui.screen.main.transferdetails.components.QrCodeBottomSheet
 import com.infomaniak.swisstransfer.ui.screen.main.transferdetails.components.TransferInfo
-import com.infomaniak.swisstransfer.ui.screen.main.transfers.NoSelectionEmptyState
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.pickfiles.components.DeeplinkPasswordAlertDialog
 import com.infomaniak.swisstransfer.ui.theme.LocalWindowAdaptiveInfo
 import com.infomaniak.swisstransfer.ui.theme.Margin
@@ -79,7 +79,6 @@ import kotlinx.coroutines.flow.emptyFlow
 fun TransferDetailsScreen(
     transferUuid: String,
     direction: TransferDirection,
-    hasTransfer: () -> Boolean,
     navigateBack: (() -> Unit)?,
     transferDetailsViewModel: TransferDetailsViewModel = hiltViewModel<TransferDetailsViewModel>(),
     navigateToFolder: (folderUuid: String) -> Unit,
@@ -97,11 +96,13 @@ fun TransferDetailsScreen(
     val context = LocalContext.current
     when (val state = uiState) {
         is Deleted -> {
-            if (windowAdaptiveInfo.isWindowSmall()) {
-                navigateBack?.invoke()
-            } else {
-                NoSelectionEmptyState(hasTransfer())
-            }
+            TransferExpiredDownloadCreditScreen(
+                onCloseClicked = if (windowAdaptiveInfo.isWindowSmall()) {
+                    { navigateBack?.invoke() }
+                } else {
+                    null
+                }
+            )
         }
         is TransferDetailsViewModel.TransferDetailsUiState.Loading -> {
             SwissTransferScaffold(topBar = { SwissTransferTopAppBar(title = "") }) {}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/TransferDetailsViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/TransferDetailsViewModel.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak SwissTransfer - Android
- * Copyright (C) 2024 Infomaniak Network SA
+ * Copyright (C) 2024-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -139,8 +139,8 @@ class TransferDetailsViewModel @Inject constructor(
             _isDeeplinkNeedingPassword.emit(false)
         }.cancellable().onFailure { exception ->
             when (exception) {
-                is ExpiredDateFetchTransferException -> longToast(R.string.deeplinkTransferExpired)
-                is DownloadQuotaExceededException -> longToast(R.string.deeplinkTransferExpired)
+                is ExpiredDateFetchTransferException -> Unit
+                is DownloadQuotaExceededException -> Unit
                 is NotFoundFetchTransferException -> longToast(R.string.deeplinkTransferNotFound)
                 is PasswordNeededFetchTransferException, is WrongPasswordFetchTransferException -> throw exception
                 else -> SentryLog.e(TAG, "An error has occurred when deeplink a transfer", exception)

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transfers/TransfersScreenWrapper.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transfers/TransfersScreenWrapper.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak SwissTransfer - Android
- * Copyright (C) 2024 Infomaniak Network SA
+ * Copyright (C) 2024-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -182,7 +182,6 @@ private fun DetailPane(
             TransferDetailsScreen(
                 transferUuid = destinationContent.transferUuid,
                 direction = destinationContent.direction,
-                hasTransfer = hasTransfer,
                 navigateBack = ScreenWrapperUtils.getBackNavigation(navigator),
                 navigateToFolder = { selectedFolderUuid ->
                     navigator.navigateToFolder(


### PR DESCRIPTION
~~A general purpose string is missing for an expired transfer.~~

~~Depends on https://github.com/Infomaniak/multiplatform-SwissTransfer/pull/178~~