### PR TITLE
fix: Use correct illustration for empty state of received screen

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/received/ReceivedScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/received/ReceivedScreen.kt
@@ -37,7 +37,7 @@ import com.infomaniak.swisstransfer.ui.components.EmptyState
 import com.infomaniak.swisstransfer.ui.components.SwissTransferTopAppBar
 import com.infomaniak.swisstransfer.ui.components.transfer.TransfersListWithExpiredBottomSheet
 import com.infomaniak.swisstransfer.ui.images.AppImages.AppIllus
-import com.infomaniak.swisstransfer.ui.images.illus.mascotWithMagnifyingGlass.MascotWithMagnifyingGlass
+import com.infomaniak.swisstransfer.ui.images.illus.mascotSearching.MascotSearching
 import com.infomaniak.swisstransfer.ui.previewparameter.GroupedTransfersPreviewParameterProvider
 import com.infomaniak.swisstransfer.ui.screen.main.components.SwissTransferScaffold
 import com.infomaniak.swisstransfer.ui.screen.main.received.components.ReceivedEmptyFab
@@ -122,7 +122,7 @@ private fun ReceivedContent(
         val shouldDisplayIcon = LocalWindowAdaptiveInfo.current.isWindowSmall()
         EmptyState(
             content = if (shouldDisplayIcon) {
-                { Image(imageVector = AppIllus.MascotWithMagnifyingGlass.image(), contentDescription = null) }
+                { Image(imageVector = AppIllus.MascotSearching.image(), contentDescription = null) }
             } else null,
             titleRes = R.string.noTransferReceivedTitle,
             descriptionRes = R.string.noTransferReceivedDescription,


### PR DESCRIPTION
The illustration should've been the one with the ghost looking through binoculars not the one with a magnifying glass