### PR TITLE
fix: Don’t block upload if notification permission is denied

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -58,7 +58,6 @@ import com.infomaniak.swisstransfer.ui.theme.Margin
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.GetSetCallbacks
 import com.infomaniak.swisstransfer.ui.utils.PreviewAllWindows
-import com.infomaniak.swisstransfer.ui.utils.guardedCallback
 import com.infomaniak.swisstransfer.upload.UploadForegroundService
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.consumeEach
@@ -165,7 +164,11 @@ fun PickFilesScreen(
         transferOptionsCallbacks = transferOptionsCallbacks,
         pickFiles = ::pickFiles,
         exitNewTransfer = { exit() },
-        onSendButtonClick = notificationPermissionState.guardedCallback { pickFilesViewModel.send() },
+        onSendButtonClick = {
+            notificationPermissionState?.launchPermissionRequest()
+            // Notification permission is optional, so we don’t wait for the result
+            pickFilesViewModel.send()
+        },
         isAwaitingSend = { pickFilesViewModel.isReadyToSend() },
         snackbarHostState = snackbarHostState,
         navigateToFilesDetails = navigateToFilesDetails,


### PR DESCRIPTION
Notifications are optional when uploading a file.