### PR TITLE
chore: Prevent UploadForegroundService from being restarted by the OS

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/upload/UploadForegroundService.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/upload/UploadForegroundService.kt
@@ -55,7 +55,7 @@ import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
 
 @AndroidEntryPoint
-class UploadForegroundService : ForegroundService(Companion, redeliverIntentIfKilled = true) {
+class UploadForegroundService : ForegroundService(Companion, redeliverIntentIfKilled = false) {
 
     companion object : ForegroundService.Companion.NoExtras<UploadForegroundService>(
         intentSpec = serviceWithoutExtrasSpec<UploadForegroundService>(),


### PR DESCRIPTION
This might fix some ForegroundServiceStartNotAllowedException issues.