### PR TITLE
feat: Auto retries + streamed upload

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/upload/InputStreamContent.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/upload/InputStreamContent.kt
@@ -53,6 +53,10 @@ private class UriContent(
     }
 }
 
+/**
+ * The implementation is copied from [InputStream.skipNBytes] that is only available starting API 34,
+ * but also supports cancellation if the [coroutineContext] is passed.
+ */
 @Throws(java.io.IOException::class)
 private fun InputStream.skipExactly(
     numberOfBytes: Long,
@@ -82,6 +86,10 @@ private fun InputStream.skipExactly(
  * Copies [count] bytes of this [InputStream] to [out].
  *
  * **Note** It is the caller's responsibility to close both of these resources.
+ *
+ * The implementation is based on the [copyTo] extension from kotlin.io,
+ * but also handles cancellation if the [coroutineContext] is passed,
+ * in addition to copying only the passed number of bytes in [count].
  */
 @Throws(java.io.IOException::class)
 private fun InputStream.copyToUntil(

--- a/app/src/main/java/com/infomaniak/swisstransfer/upload/InputStreamContent.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/upload/InputStreamContent.kt
@@ -92,11 +92,10 @@ private fun InputStream.copyToUntil(
 ) {
     var bytesRemaining: Long = count
     val buffer = ByteArray(bufferSize)
-    var readBytesCount = 0
     do {
         coroutineContext.ensureActive()
         val bytesToCopy = minOf(bytesRemaining, bufferSize.toLong()).toInt()
-        readBytesCount = read(buffer, 0, bytesToCopy)
+        val readBytesCount = read(/* b = */ buffer, /* off = */ 0, /* len = */ bytesToCopy)
         if (readBytesCount == 0) {
             throw IOException("Wanted to read $bytesToCopy bytes but got zero. $bytesRemaining/$count bytes couldn't be copied.")
         } else if (readBytesCount < 0) {

--- a/app/src/main/java/com/infomaniak/swisstransfer/upload/InputStreamContent.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/upload/InputStreamContent.kt
@@ -104,11 +104,12 @@ private fun InputStream.copyToUntil(
         coroutineContext.ensureActive()
         val bytesToCopy = minOf(bytesRemaining, bufferSize.toLong()).toInt()
         val readBytesCount = read(/* b = */ buffer, /* off = */ 0, /* len = */ bytesToCopy)
+
         if (readBytesCount == 0) {
             throw IOException("Wanted to read $bytesToCopy bytes but got zero. $bytesRemaining/$count bytes couldn't be copied.")
-        } else if (readBytesCount < 0) {
-            throw EOFException("$bytesRemaining/$count bytes couldn't be copied.")
         }
+        if (readBytesCount < 0) throw EOFException("$bytesRemaining/$count bytes couldn't be copied.")
+
         coroutineContext.ensureActive()
         out.write(
             /* b = */ buffer,

--- a/app/src/main/java/com/infomaniak/swisstransfer/upload/InputStreamContent.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/upload/InputStreamContent.kt
@@ -1,0 +1,113 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.swisstransfer.upload
+
+import android.net.Uri
+import io.ktor.http.content.OutgoingContent
+import io.ktor.utils.io.ByteWriteChannel
+import io.ktor.utils.io.jvm.javaio.toOutputStream
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.invoke
+import kotlinx.io.IOException
+import splitties.init.appCtx
+import java.io.EOFException
+import java.io.InputStream
+import java.io.OutputStream
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+fun Uri.toContentChunk(
+    offset: Long,
+    length: Long,
+): OutgoingContent.WriteChannelContent = UriContent(targetFileUri = this, offset = offset, contentLength = length)
+
+private class UriContent(
+    private val targetFileUri: Uri,
+    private val offset: Long,
+    override val contentLength: Long
+) : OutgoingContent.WriteChannelContent() {
+
+    override suspend fun writeTo(channel: ByteWriteChannel) = Dispatchers.IO {
+        val stream = appCtx.contentResolver.openInputStream(targetFileUri)
+            ?: throw IOException("The provider for the following Uri recently crashed: $targetFileUri")
+        stream.buffered().use { inputStream ->
+            inputStream.skipExactly(numberOfBytes = offset, coroutineContext)
+            inputStream.copyToUntil(channel.toOutputStream(), count = contentLength, coroutineContext = coroutineContext)
+        }
+    }
+}
+
+@Throws(java.io.IOException::class)
+private fun InputStream.skipExactly(
+    numberOfBytes: Long,
+    coroutineContext: CoroutineContext = EmptyCoroutineContext
+) {
+    var n = numberOfBytes
+    while (n > 0) {
+        coroutineContext.ensureActive()
+        val ns: Long = skip(n)
+        if (ns > 0 && ns <= n) {
+            // adjust number to skip
+            n -= ns
+        } else if (ns == 0L) { // no bytes skipped
+            // read one byte to check for EOS
+            if (read() == -1) {
+                throw EOFException()
+            }
+            // one byte read so decrement number to skip
+            n--
+        } else { // skipped negative or too many bytes
+            throw IOException("Unable to skip exactly")
+        }
+    }
+}
+
+/**
+ * Copies [count] bytes of this [InputStream] to [out].
+ *
+ * **Note** It is the caller's responsibility to close both of these resources.
+ */
+@Throws(java.io.IOException::class)
+private fun InputStream.copyToUntil(
+    out: OutputStream,
+    bufferSize: Int = DEFAULT_BUFFER_SIZE,
+    count: Long,
+    coroutineContext: CoroutineContext = EmptyCoroutineContext
+) {
+    var bytesRemaining: Long = count
+    val buffer = ByteArray(bufferSize)
+    var readBytesCount = 0
+    do {
+        coroutineContext.ensureActive()
+        val bytesToCopy = minOf(bytesRemaining, bufferSize.toLong()).toInt()
+        readBytesCount = read(buffer, 0, bytesToCopy)
+        if (readBytesCount == 0) {
+            throw IOException("Wanted to read $bytesToCopy bytes but got zero. $bytesRemaining/$count bytes couldn't be copied.")
+        } else if (readBytesCount < 0) {
+            throw EOFException("$bytesRemaining/$count bytes couldn't be copied.")
+        }
+        coroutineContext.ensureActive()
+        out.write(
+            /* b = */ buffer,
+            /* off = */ 0,
+            /* len = */ readBytesCount
+        )
+        bytesRemaining -= readBytesCount
+    } while (bytesRemaining > 0)
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/upload/InputStreamContent.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/upload/InputStreamContent.kt
@@ -87,7 +87,7 @@ private fun InputStream.skipExactly(
  *
  * **Note** It is the caller's responsibility to close both of these resources.
  *
- * The implementation is based on the [copyTo] extension from kotlin.io,
+ * The implementation is based on the [java.io.InputStream.copyTo] extension from kotlin.io,
  * but also handles cancellation if the [coroutineContext] is passed,
  * in addition to copying only the passed number of bytes in [count].
  */

--- a/app/src/main/java/com/infomaniak/swisstransfer/upload/TransferUploader.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/upload/TransferUploader.kt
@@ -234,7 +234,7 @@ class TransferUploader(
 
         val chunkSize = metadata.chunkConfig.fileChunkSize
         val totalFileSize = metadata.pickedFile.size
-        val content = metadata.pickedFile.uri.toContentChunk(
+        val chunkedContent = metadata.pickedFile.uri.toOutgoingContent(
             offset = chunkSize * chunkIndex,
             length = if (isLastChunk) {
                 (totalFileSize % chunkSize).let { if (it == 0L) chunkSize.toLong() else it }
@@ -256,7 +256,7 @@ class TransferUploader(
                     fileUUID = fileUuid,
                     chunkIndex = chunkIndex,
                     isLastChunk = isLastChunk,
-                    data = content
+                    data = chunkedContent
                 )
             }
         }

--- a/app/src/main/java/com/infomaniak/swisstransfer/upload/TransferUploader.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/upload/TransferUploader.kt
@@ -160,7 +160,6 @@ class TransferUploader(
         val fileUUID: String = metadata.uuid
         SentryLog.i(TAG, "start upload file $fileUUID, with size ${metadata.pickedFile.size}")
 
-
         if (metadata.thumbnailSaved.not()) targetFileUri.getMimeType()?.let { mimeType ->
             thumbnailsLocalStorage.generateThumbnailFor(
                 fileUri = targetFileUri,

--- a/app/src/main/java/com/infomaniak/swisstransfer/upload/TransferUploader.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/upload/TransferUploader.kt
@@ -205,7 +205,7 @@ class TransferUploader(
 
         syncFileChunksUploadStatuses(metadata, totalChunks)
 
-        val requestSemaphore = Semaphore(chunkConfig.parallelChunks.coerceIn(3, 8))
+        val requestSemaphore = Semaphore(chunkConfig.parallelChunks)
 
         val lastChunkIndex = totalChunks - 1
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/upload/TransferUploader.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/upload/TransferUploader.kt
@@ -228,11 +228,10 @@ class TransferUploader(
             SentryLog.d(TAG, "skipping chunk #$chunkIndex since it's already been uploaded (file $fileUuid)")
             return
         }
-        val targetFileUri = metadata.pickedFile.uri
 
         val chunkSize = metadata.chunkConfig.fileChunkSize
         val totalFileSize = metadata.pickedFile.size
-        val content = targetFileUri.toContentChunk(
+        val content = metadata.pickedFile.uri.toContentChunk(
             offset = chunkSize * chunkIndex,
             length = if (isLastChunk) {
                 (totalFileSize % chunkSize).let { if (it == 0L) chunkSize.toLong() else it }

--- a/app/src/main/java/com/infomaniak/swisstransfer/upload/TransferUploader.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/upload/TransferUploader.kt
@@ -42,7 +42,6 @@ import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.minusAssign
 import kotlin.concurrent.atomics.plusAssign
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource

--- a/app/src/main/java/com/infomaniak/swisstransfer/upload/TransferUploader.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/upload/TransferUploader.kt
@@ -238,7 +238,9 @@ class TransferUploader(
             offset = chunkSize * chunkIndex,
             length = if (isLastChunk) {
                 (totalFileSize % chunkSize).let { if (it == 0L) chunkSize.toLong() else it }
-            } else chunkSize
+            } else {
+                chunkSize
+            }
         )
         metadata.chunksUploadStatus[chunkIndex] = StartedOrComplete
         withRetries { isRetrying ->

--- a/app/src/main/java/com/infomaniak/swisstransfer/upload/TransferUploader.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/upload/TransferUploader.kt
@@ -266,7 +266,8 @@ class TransferUploader(
                 if (timeUntilGiveUp < Duration.ZERO) throw e
                 val retryIn = (minDelayBetweenRetries * attemptNumber)
                     .coerceAtMost(maxDelayBetweenRetries)
-                    .coerceAtMost(timeUntilGiveUp)
+                    .coerceAtMost(timeUntilGiveUp) // Ensure the last retry doesn't happen after `giveUpDelay`,
+                // so that we don't need to mentally calculate when the last retry could happen.
                 delay(retryIn)
             }
         }

--- a/app/src/main/java/com/infomaniak/swisstransfer/upload/TransferUploader.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/upload/TransferUploader.kt
@@ -255,8 +255,8 @@ class TransferUploader(
         val maxGiveUpDelay = 40.seconds
         val maxDelayBetweenRetries = 10.seconds
         val minDelayBetweenRetries = 500.milliseconds
-        var attemptNumber = 0
         val attemptTimeMark = TimeSource.Monotonic.markNow()
+        var attemptNumber = 0
         while (true) {
             try {
                 attemptNumber++

--- a/app/src/main/java/com/infomaniak/swisstransfer/upload/UriToOutgoingContent.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/upload/UriToOutgoingContent.kt
@@ -49,6 +49,8 @@ fun Uri.toOutgoingContent(
 }
 
 /**
+ * **DISCLAIMER: Code copied from the JDK, might not follow all our coding conventions.**
+ *
  * The implementation is copied from [InputStream.skipNBytes] that is only available starting API 34,
  * but also supports cancellation if the [coroutineContext] is passed.
  */

--- a/app/src/main/java/com/infomaniak/swisstransfer/upload/UriToOutgoingContent.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/upload/UriToOutgoingContent.kt
@@ -36,6 +36,7 @@ fun Uri.toOutgoingContent(
     offset: Long,
     length: Long,
 ): OutgoingContent.WriteChannelContent = object : OutgoingContent.WriteChannelContent() {
+    override val contentLength = length
 
     override suspend fun writeTo(channel: ByteWriteChannel) = Dispatchers.IO {
         val targetFileUri = this@toOutgoingContent

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ lottie = "6.6.2"
 navigation = "2.8.9"
 qrose = "1.0.1"
 sentry = "5.2.0"
-swisstransfer = "3.0.3"
+swisstransfer = "3.1.0"
 workmanager = "2.10.0"
 
 [libraries]


### PR DESCRIPTION
This PR reduces the memory consumption dramatically (first commit), and implements automatic retries (second commit).

It also simplifies the logic that we used to ensure that the last chunk was sent only after all the previous ones were sent.

Depends on https://github.com/Infomaniak/android-core/pull/324
Depends on https://github.com/Infomaniak/multiplatform-SwissTransfer/pull/200

Also requires a version of the KMP module to be released.