### PR TITLE
feat(Sentry): Hook KMP error interface with Sentry

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/di/CrashReportImpl.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/di/CrashReportImpl.kt
@@ -20,6 +20,7 @@ package com.infomaniak.swisstransfer.di
 import com.infomaniak.multiplatform_swisstransfer.common.interfaces.CrashReportInterface
 import com.infomaniak.multiplatform_swisstransfer.common.interfaces.CrashReportLevel
 import io.sentry.Breadcrumb
+import io.sentry.ScopeCallback
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 
@@ -43,10 +44,20 @@ val crashReport = object: CrashReportInterface {
     }
 
     override fun capture(error: Throwable, data: Map<String, Any>?, category: String?) {
-        Sentry.captureException(error)
+        Sentry.captureException(error) { scope ->
+            data.forEach { (key, value) ->
+                scope.setExtra(key, value.toString())
+            }
+            scope.setTag("category", category)
+        }
     }
 
     override fun capture(message: String, data: Map<String, Any>?, category: String?, level: CrashReportLevel?) {
-        Sentry.captureMessage(message, level?.sentryLevel ?: SentryLevel.INFO)
+        Sentry.captureMessage(message, level?.sentryLevel ?: SentryLevel.INFO) { scope ->
+            data.forEach { (key, value) ->
+                scope.setExtra(key, value.toString())
+            }
+            scope.setTag("category", category)
+        }
     }
 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/di/CrashReportImpl.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/di/CrashReportImpl.kt
@@ -44,18 +44,14 @@ val crashReport = object : CrashReportInterface {
 
     override fun capture(error: Throwable, data: Map<String, Any>?, category: String?) {
         Sentry.captureException(error) { scope ->
-            data.forEach { (key, value) ->
-                scope.setExtra(key, value.toString())
-            }
+            data?.forEach { (key, value) -> scope.setExtra(key, value.toString()) }
             scope.setTag("category", category)
         }
     }
 
     override fun capture(message: String, data: Map<String, Any>?, category: String?, level: CrashReportLevel?) {
         Sentry.captureMessage(message, level?.sentryLevel ?: SentryLevel.INFO) { scope ->
-            data.forEach { (key, value) ->
-                scope.setExtra(key, value.toString())
-            }
+            data?.forEach { (key, value) -> scope.setExtra(key, value.toString()) }
             scope.setTag("category", category)
         }
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/di/CrashReportImpl.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/di/CrashReportImpl.kt
@@ -20,7 +20,6 @@ package com.infomaniak.swisstransfer.di
 import com.infomaniak.multiplatform_swisstransfer.common.interfaces.CrashReportInterface
 import com.infomaniak.multiplatform_swisstransfer.common.interfaces.CrashReportLevel
 import io.sentry.Breadcrumb
-import io.sentry.ScopeCallback
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 
@@ -33,7 +32,7 @@ val CrashReportLevel.sentryLevel: SentryLevel
         CrashReportLevel.FATAL -> SentryLevel.FATAL
     }
 
-val crashReport = object: CrashReportInterface {
+val crashReport = object : CrashReportInterface {
     override fun addBreadcrumb(message: String, category: String, level: CrashReportLevel, data: Map<String, Any>?) {
         val breadcrumb = Breadcrumb()
         breadcrumb.message = message

--- a/app/src/main/java/com/infomaniak/swisstransfer/di/CrashReportImpl.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/di/CrashReportImpl.kt
@@ -1,0 +1,54 @@
+/*
+ * Infomaniak SwissTransfer - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.swisstransfer.di
+
+import com.infomaniak.multiplatform_swisstransfer.common.interfaces.CrashReportInterface
+import com.infomaniak.multiplatform_swisstransfer.common.interfaces.CrashReportLevel
+import io.sentry.Breadcrumb
+import io.sentry.Sentry
+import io.sentry.SentryLevel
+
+val CrashReportLevel.sentryLevel: SentryLevel
+    get() = when (this) {
+        CrashReportLevel.DEBUG -> SentryLevel.DEBUG
+        CrashReportLevel.INFO -> SentryLevel.INFO
+        CrashReportLevel.WARNING -> SentryLevel.WARNING
+        CrashReportLevel.ERROR -> SentryLevel.ERROR
+        CrashReportLevel.FATAL -> SentryLevel.FATAL
+    }
+
+val crashReport = object: CrashReportInterface {
+    override fun addBreadcrumb(message: String, category: String, level: CrashReportLevel, data: Map<String, Any>?) {
+        var breadcrumb = Breadcrumb()
+        breadcrumb.message = message
+        breadcrumb.category = category
+        breadcrumb.level = level.sentryLevel
+        data?.forEach { (key, value) ->
+            breadcrumb.setData(key, value)
+        }
+        Sentry.addBreadcrumb(breadcrumb)
+    }
+
+    override fun capture(error: Throwable, data: Map<String, Any>?, category: String?) {
+        Sentry.captureException(error)
+    }
+
+    override fun capture(message: String, data: Map<String, Any>?, category: String?, level: CrashReportLevel?) {
+        Sentry.captureMessage(message, level?.sentryLevel ?: SentryLevel.INFO)
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/di/CrashReportImpl.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/di/CrashReportImpl.kt
@@ -34,13 +34,11 @@ val CrashReportLevel.sentryLevel: SentryLevel
 
 val crashReport = object: CrashReportInterface {
     override fun addBreadcrumb(message: String, category: String, level: CrashReportLevel, data: Map<String, Any>?) {
-        var breadcrumb = Breadcrumb()
+        val breadcrumb = Breadcrumb()
         breadcrumb.message = message
         breadcrumb.category = category
         breadcrumb.level = level.sentryLevel
-        data?.forEach { (key, value) ->
-            breadcrumb.setData(key, value)
-        }
+        data?.forEach { (key, value) -> breadcrumb.setData(key, value) }
         Sentry.addBreadcrumb(breadcrumb)
     }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/di/SwissTransferInjectionModule.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/di/SwissTransferInjectionModule.kt
@@ -33,7 +33,11 @@ object SwissTransferInjectionModule {
     @Provides
     @Singleton
     fun providesSwissTransferInjection(@UserAgent userAgent: String): SwissTransferInjection {
-        return SwissTransferInjection(environment = ApiEnvironment.Custom(BuildConfig.BASE_URL), userAgent = userAgent)
+        return SwissTransferInjection(
+            environment = ApiEnvironment.Custom(BuildConfig.BASE_URL),
+            userAgent = userAgent,
+            crashReport = crashReport
+        )
     }
 
     @Provides

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/AlreadyUsedFileNamesSet.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/AlreadyUsedFileNamesSet.kt
@@ -17,6 +17,7 @@
  */
 package com.infomaniak.swisstransfer.ui.screen.newtransfer
 
+import com.infomaniak.swisstransfer.ui.screen.newtransfer.AlreadyUsedFileNamesSet.AlreadyUsedStrategy
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ lottie = "6.6.2"
 navigation = "2.8.9"
 qrose = "1.0.1"
 sentry = "5.2.0"
-swisstransfer = "3.1.1"
+swisstransfer = "4.0.0"
 workmanager = "2.10.0"
 
 [libraries]


### PR DESCRIPTION
#### Abstract

This PR hooks the new error reporting interface with the existing Sentry instance.

Depends on https://github.com/Infomaniak/multiplatform-SwissTransfer/pull/202

iOS sister PR https://github.com/Infomaniak/ios-SwissTransfer/pull/216