### PR TITLE
chore: Improve Gradle plugins version management

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,9 @@ buildscript {
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
-    alias(core.plugins.kotlin.android) apply false
-    alias(core.plugins.compose.compiler) apply false
+    alias(core.plugins.kotlin.android) version libs.versions.kotlin apply false
+    alias(core.plugins.compose.compiler) version libs.versions.kotlin apply false
     alias(libs.plugins.kapt) apply false
     alias(libs.plugins.hilt) apply false
+    kotlin("plugin.serialization") version libs.versions.kotlin apply false
 }


### PR DESCRIPTION
This allows the project to use Kotlin 2.1+ safely.