### PR TITLE
fix: Remove QR Code and Proximity

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
@@ -94,7 +94,7 @@ class PickFilesViewModel @Inject constructor(
 
     val importedFilesDebounced: StateFlow<List<FileUi>>
 
-    val selectedTransferTypeFlow = savedStateHandle.getStateFlow(SELECTED_TRANSFER_TYPE, TransferTypeUi.QrCode)
+    val selectedTransferTypeFlow = savedStateHandle.getStateFlow(SELECTED_TRANSFER_TYPE, TransferTypeUi.Link)
 
     fun importUris(uris: List<Uri>) {
         UploadForegroundService.addFiles(uris)

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/components/TransferTypeButtons.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/components/TransferTypeButtons.kt
@@ -27,12 +27,12 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.Dp
 import com.infomaniak.core.compose.margin.Margin
 import com.infomaniak.multiplatform_swisstransfer.common.models.TransferType
+import com.infomaniak.multiplatform_swisstransfer.common.models.TransferType.LINK
+import com.infomaniak.multiplatform_swisstransfer.common.models.TransferType.MAIL
 import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.images.AppImages.AppIcons
 import com.infomaniak.swisstransfer.ui.images.icons.Chain
 import com.infomaniak.swisstransfer.ui.images.icons.Envelope
-import com.infomaniak.swisstransfer.ui.images.icons.QrCode
-import com.infomaniak.swisstransfer.ui.images.icons.WifiWave
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.pickfiles.components.TransferTypeUi.Companion.toTransferTypeUi
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.GetSetCallbacks
@@ -73,13 +73,6 @@ enum class TransferTypeUi(
     @StringRes @PluralsRes val descriptionRes: Int?,
     val dbValue: TransferType,
 ) {
-    QrCode(
-        buttonIcon = AppIcons.QrCode,
-        buttonTextRes = R.string.transferTypeQrCode,
-        titleRes = R.string.uploadSuccessQrTitle,
-        descriptionRes = null,
-        dbValue = TransferType.QR_CODE,
-    ),
     Mail(
         buttonIcon = AppIcons.Envelope,
         buttonTextRes = R.string.transferTypeEmail,
@@ -93,21 +86,12 @@ enum class TransferTypeUi(
         titleRes = R.string.uploadSuccessLinkTitle,
         descriptionRes = R.string.uploadSuccessLinkDescription,
         dbValue = TransferType.LINK,
-    ),
-    Proximity(
-        buttonIcon = AppIcons.WifiWave,
-        buttonTextRes = R.string.transferTypeProximity,
-        titleRes = R.string.uploadSuccessLinkTitle,
-        descriptionRes = R.string.uploadSuccessLinkDescription,
-        dbValue = TransferType.PROXIMITY,
     );
 
     companion object {
         fun TransferType.toTransferTypeUi() = when (this) {
-            TransferType.LINK -> Link
-            TransferType.QR_CODE -> QrCode
-            TransferType.PROXIMITY -> Proximity
-            TransferType.MAIL -> Mail
+            LINK -> Link
+            MAIL -> Mail
         }
     }
 }
@@ -119,7 +103,7 @@ private fun TransferTypeButtonsPreview() {
         Surface {
             TransferTypeButtons(
                 horizontalPadding = Margin.Medium,
-                transferType = GetSetCallbacks(get = { TransferTypeUi.QrCode }, set = {}),
+                transferType = GetSetCallbacks(get = { TransferTypeUi.Link }, set = {}),
             )
         }
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadSuccessQrScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadSuccessQrScreen.kt
@@ -126,7 +126,7 @@ private fun UploadSuccessQrScreenPreview() {
     SwissTransferTheme {
         Surface {
             UploadSuccessQrScreen(
-                transferType = TransferTypeUi.QrCode,
+                transferType = TransferTypeUi.Link,
                 transferUrl = "https://chk.me/83azQOl",
                 exitNewTransfer = {}
             )

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadSuccessScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/upload/UploadSuccessScreen.kt
@@ -62,7 +62,7 @@ private fun UploadSuccessScreenPreview() {
     SwissTransferTheme {
         Surface {
             UploadSuccessScreen(
-                transferType = TransferTypeUi.QrCode,
+                transferType = TransferTypeUi.Link,
                 transferUuid = "",
                 transferUrl = "https://chk.me/83azQOl",
                 dismissCompleteUpload = {},

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ navigation = "2.9.1"
 qrose = "1.0.1"
 room = "2.7.2"
 sentry = "5.5.0"
-swisstransfer = "5.1.0"
+swisstransfer = "5.2.0"
 workVersion = "2.10.2"
 
 [libraries]


### PR DESCRIPTION
When creating a transfer, we removed the button to transfer as a QR code, and Proximity