### PR TITLE
fix: Ensure the snackbar is above the navigation bar

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/TransferDetailsScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/TransferDetailsScreen.kt
@@ -241,7 +241,10 @@ private fun TransferDetailsScreen(
                 }
             )
         },
-        snackbarHost = { SnackbarHost(snackbarHostState) },
+        snackbarHost = {
+            // Modifier.navigationBarsPadding() wouldn't work here, but this does.
+            SnackbarHost(snackbarHostState, Modifier.padding(getBottomBarPadding()))
+        },
     ) {
         Column {
 


### PR DESCRIPTION
If you want to test the change, I advise you to add this code somewhere, it's easier than causing `DownloadManager` to give up and go into error state:
```kotlin
LaunchedEffect(Unit) { snackbarHostState.showSnackbar("Hello!") }
```