### PR TITLE
feat: Add email contact picker when sending by email

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/TwoPaneScaffold.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/TwoPaneScaffold.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak SwissTransfer - Android
- * Copyright (C) 2024 Infomaniak Network SA
+ * Copyright (C) 2024-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,7 +20,6 @@ package com.infomaniak.swisstransfer.ui.components
 import android.content.Context
 import androidx.activity.compose.BackHandler
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
-import androidx.compose.material3.adaptive.WindowAdaptiveInfo
 import androidx.compose.material3.adaptive.layout.AnimatedPane
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffold
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
@@ -52,7 +51,6 @@ private val backBehavior = BackNavigationBehavior.PopUntilContentChange
  * between list and detail panes.
  * @param T the type representing the item displayed in the detail pane. This can be an item id or a whole instance.
  * This type must be storable in a Bundle. If this customization is unneeded, you can pass [Nothing]
- * @param windowAdaptiveInfo An instance of [WindowAdaptiveInfo] that provides information about
  * the current window's size class and adaptive state.
  * @param listPane A composable function that describes the content of the list pane.
  * @param detailPane A composable function that describes the content of the detail pane.

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/images/icons/PersonsCircleAdd.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/images/icons/PersonsCircleAdd.kt
@@ -1,8 +1,7 @@
 package com.infomaniak.swisstransfer.ui.images.icons
 
-import androidx.compose.foundation.Image
+simport androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/images/icons/PersonsCircleAdd.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/images/icons/PersonsCircleAdd.kt
@@ -1,6 +1,6 @@
 package com.infomaniak.swisstransfer.ui.images.icons
 
-simport androidx.compose.foundation.Image
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/images/icons/PersonsCircleAdd.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/images/icons/PersonsCircleAdd.kt
@@ -1,0 +1,133 @@
+package com.infomaniak.swisstransfer.ui.images.icons
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.group
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.infomaniak.swisstransfer.ui.images.AppImages
+import com.infomaniak.swisstransfer.ui.images.AppImages.AppIcons
+import androidx.compose.ui.graphics.StrokeCap.Companion.Round as strokeCapRound
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Round as strokeJoinRound
+
+val AppIcons.PersonsCircleAdd: ImageVector
+    get() {
+        if (_personsCircleAdd != null) {
+            return _personsCircleAdd!!
+        }
+        _personsCircleAdd = Builder(
+            name = "PersonsCircleAdd",
+            defaultWidth = 24.0.dp,
+            defaultHeight = 24.0.dp,
+            viewportWidth = 24.0f,
+            viewportHeight = 24.0f,
+        ).apply {
+            group {
+                path(
+                    fill = SolidColor(Color(0xFF9F9F9F)),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(18.0f, 12.0f)
+                    curveTo(19.591f, 12.0f, 21.117f, 12.633f, 22.242f, 13.758f)
+                    curveTo(23.367f, 14.883f, 24.0f, 16.409f, 24.0f, 18.0f)
+                    curveTo(24.0f, 19.591f, 23.367f, 21.117f, 22.242f, 22.242f)
+                    curveTo(21.117f, 23.367f, 19.591f, 24.0f, 18.0f, 24.0f)
+                    curveTo(16.409f, 24.0f, 14.883f, 23.367f, 13.758f, 22.242f)
+                    curveTo(12.633f, 21.117f, 12.0f, 19.591f, 12.0f, 18.0f)
+                    curveTo(12.0f, 16.409f, 12.633f, 14.883f, 13.758f, 13.758f)
+                    curveTo(14.883f, 12.633f, 16.409f, 12.0f, 18.0f, 12.0f)
+                    close()
+                    moveTo(18.0f, 14.0f)
+                    curveTo(17.586f, 14.0f, 17.25f, 14.336f, 17.25f, 14.75f)
+                    verticalLineTo(17.25f)
+                    horizontalLineTo(14.75f)
+                    curveTo(14.336f, 17.25f, 14.0f, 17.586f, 14.0f, 18.0f)
+                    curveTo(14.0f, 18.414f, 14.336f, 18.75f, 14.75f, 18.75f)
+                    horizontalLineTo(17.25f)
+                    verticalLineTo(21.25f)
+                    curveTo(17.25f, 21.664f, 17.586f, 22.0f, 18.0f, 22.0f)
+                    curveTo(18.414f, 22.0f, 18.75f, 21.664f, 18.75f, 21.25f)
+                    verticalLineTo(18.75f)
+                    horizontalLineTo(21.25f)
+                    curveTo(21.664f, 18.75f, 22.0f, 18.414f, 22.0f, 18.0f)
+                    curveTo(22.0f, 17.586f, 21.664f, 17.25f, 21.25f, 17.25f)
+                    horizontalLineTo(18.75f)
+                    verticalLineTo(14.75f)
+                    curveTo(18.75f, 14.336f, 18.414f, 14.0f, 18.0f, 14.0f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFF9F9F9F)),
+                    strokeLineWidth = 1.5f,
+                    strokeLineCap = strokeCapRound,
+                    strokeLineJoin = strokeJoinRound,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(13.071f, 10.047f)
+                    curveTo(13.58f, 9.824f, 14.134f, 9.705f, 14.7f, 9.705f)
+                    curveTo(15.601f, 9.705f, 16.47f, 10.004f, 17.175f, 10.548f)
+                    moveTo(2.85f, 4.046f)
+                    curveTo(2.85f, 4.92f, 3.197f, 5.758f, 3.816f, 6.377f)
+                    curveTo(4.435f, 6.995f, 5.274f, 7.342f, 6.15f, 7.342f)
+                    curveTo(7.025f, 7.342f, 7.864f, 6.995f, 8.483f, 6.377f)
+                    curveTo(9.102f, 5.758f, 9.449f, 4.92f, 9.449f, 4.046f)
+                    curveTo(9.449f, 3.172f, 9.102f, 2.333f, 8.483f, 1.715f)
+                    curveTo(7.864f, 1.097f, 7.025f, 0.75f, 6.15f, 0.75f)
+                    curveTo(5.274f, 0.75f, 4.435f, 1.097f, 3.816f, 1.715f)
+                    curveTo(3.197f, 2.333f, 2.85f, 3.172f, 2.85f, 4.046f)
+                    close()
+                    moveTo(12.225f, 6.216f)
+                    curveTo(12.225f, 6.872f, 12.486f, 7.501f, 12.95f, 7.964f)
+                    curveTo(13.414f, 8.428f, 14.044f, 8.688f, 14.7f, 8.688f)
+                    curveTo(15.356f, 8.688f, 15.986f, 8.428f, 16.45f, 7.964f)
+                    curveTo(16.914f, 7.501f, 17.175f, 6.872f, 17.175f, 6.216f)
+                    curveTo(17.175f, 5.561f, 16.914f, 4.932f, 16.45f, 4.468f)
+                    curveTo(15.986f, 4.005f, 15.356f, 3.744f, 14.7f, 3.744f)
+                    curveTo(14.044f, 3.744f, 13.414f, 4.005f, 12.95f, 4.468f)
+                    curveTo(12.486f, 4.932f, 12.225f, 5.561f, 12.225f, 6.216f)
+                    close()
+                    moveTo(0.75f, 13.75f)
+                    curveTo(0.75f, 12.32f, 1.319f, 10.948f, 2.332f, 9.936f)
+                    curveTo(3.344f, 8.925f, 4.718f, 8.357f, 6.15f, 8.357f)
+                    curveTo(7.582f, 8.357f, 8.955f, 8.925f, 9.968f, 9.936f)
+                    curveTo(10.98f, 10.948f, 11.549f, 12.32f, 11.549f, 13.75f)
+                    horizontalLineTo(0.75f)
+                    close()
+                }
+            }
+        }.build()
+        return _personsCircleAdd!!
+    }
+
+private var _personsCircleAdd: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box {
+        Image(
+            imageVector = AppIcons.PersonsCircleAdd,
+            contentDescription = null,
+            modifier = Modifier.size(AppImages.previewSize)
+        )
+    }
+}

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/images/icons/PersonsCircleAdd.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/images/icons/PersonsCircleAdd.kt
@@ -8,8 +8,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
-import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.group

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/images/icons/PersonsCircleAdd.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/images/icons/PersonsCircleAdd.kt
@@ -36,11 +36,6 @@ val AppIcons.PersonsCircleAdd: ImageVector
             group {
                 path(
                     fill = SolidColor(Color(0xFF9F9F9F)),
-                    stroke = null,
-                    strokeLineWidth = 0.0f,
-                    strokeLineCap = Butt,
-                    strokeLineJoin = Miter,
-                    strokeLineMiter = 4.0f,
                     pathFillType = NonZero,
                 ) {
                     moveTo(18.0f, 12.0f)

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -18,8 +18,14 @@
 package com.infomaniak.swisstransfer.ui.screen.newtransfer.pickfiles
 
 import android.Manifest
+import android.app.Activity
 import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.ACTION_PICK
+import android.net.Uri
 import android.os.Build.VERSION.SDK_INT
+import android.provider.ContactsContract
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -27,13 +33,18 @@ import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -45,10 +56,13 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -71,10 +85,17 @@ import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.LocalUser
 import com.infomaniak.swisstransfer.ui.MatomoSwissTransfer
 import com.infomaniak.swisstransfer.ui.components.ButtonType
+import com.infomaniak.swisstransfer.ui.components.FabType
 import com.infomaniak.swisstransfer.ui.components.LargeButton
+import com.infomaniak.swisstransfer.ui.components.SwissTransferFab
 import com.infomaniak.swisstransfer.ui.components.SwissTransferTextField
 import com.infomaniak.swisstransfer.ui.components.SwissTransferTopAppBar
 import com.infomaniak.swisstransfer.ui.components.TopAppBarButtons
+import com.infomaniak.swisstransfer.ui.images.AppImages
+import com.infomaniak.swisstransfer.ui.images.AppImages.AppIcons
+import com.infomaniak.swisstransfer.ui.images.icons.EyeCrossed
+import com.infomaniak.swisstransfer.ui.images.icons.Person
+import com.infomaniak.swisstransfer.ui.images.icons.PersonsCircleAdd
 import com.infomaniak.swisstransfer.ui.previewparameter.filesPreviewData
 import com.infomaniak.swisstransfer.ui.screen.main.settings.DownloadLimitOption
 import com.infomaniak.swisstransfer.ui.screen.main.settings.EmailLanguageOption
@@ -88,12 +109,14 @@ import com.infomaniak.swisstransfer.ui.screen.newtransfer.pickfiles.components.T
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.pickfiles.components.TransferOptionsTypes
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.pickfiles.components.TransferTypeButtons
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.pickfiles.components.TransferTypeUi
+import com.infomaniak.swisstransfer.ui.theme.Dimens
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.GetSetCallbacks
 import com.infomaniak.swisstransfer.ui.utils.isApiV2
 import com.infomaniak.swisstransfer.upload.UploadForegroundService
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.launch
 import splitties.toast.longToast
 
 private val HORIZONTAL_PADDING = Margin.Medium
@@ -197,6 +220,7 @@ fun PickFilesScreen(
         ),
         transferOptionsCallbacks = transferOptionsCallbacks,
         pickFiles = ::pickFiles,
+        selectContact = pickFilesViewModel::processContactPickerResultUri,
         exitNewTransfer = { exit() },
         onSendButtonClick = {
             MatomoSwissTransfer.trackNewTransferDataEvent(pickFilesViewModel.selectedTransferTypeFlow.value.dbValue.matomoName)
@@ -227,6 +251,7 @@ private fun PickFilesScreen(
     selectedTransferType: GetSetCallbacks<TransferTypeUi>,
     transferOptionsCallbacks: TransferOptionsCallbacks,
     pickFiles: () -> Unit,
+    selectContact: (Uri, Context) -> Unit,
     exitNewTransfer: () -> Unit,
     isAwaitingSend: () -> Boolean,
     onSendButtonClick: () -> Unit,
@@ -264,6 +289,7 @@ private fun PickFilesScreen(
                     emailTextFieldCallbacks = emailTextFieldCallbacks,
                     transferMessageCallbacks = transferMessageCallbacks,
                     shouldShowEmailAddressesFields = { shouldShowEmailAddressesFields },
+                    selectContact = selectContact,
                 )
                 TransferOptions(modifier, transferOptionsCallbacks)
             }
@@ -297,6 +323,7 @@ private fun ImportTextFields(
     emailTextFieldCallbacks: EmailTextFieldCallbacks,
     transferMessageCallbacks: GetSetCallbacks<String>,
     shouldShowEmailAddressesFields: () -> Boolean,
+    selectContact: (Uri, Context) -> Unit,
 ) {
     val modifier = horizontalPaddingModifier.fillMaxWidth()
 
@@ -312,7 +339,9 @@ private fun ImportTextFields(
             )
         }
 
-        EmailAddressesTextFields(modifier, emailTextFieldCallbacks, shouldShowEmailAddressesFields, textFieldSpacing)
+        EmailAddressesTextFields(
+            modifier, emailTextFieldCallbacks, shouldShowEmailAddressesFields, textFieldSpacing, selectContact
+        )
 
         SwissTransferTextField(
             modifier = modifier,
@@ -331,7 +360,34 @@ private fun EmailAddressesTextFields(
     emailTextFieldCallbacks: EmailTextFieldCallbacks,
     shouldShowEmailAddressesFields: () -> Boolean,
     textFieldSpacing: Dp,
+    selectContact: (Uri, Context) -> Unit,
 ) = with(emailTextFieldCallbacks) {
+    val context = LocalContext.current
+    val coroutine = rememberCoroutineScope()
+
+    val pickContact = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        if (it.resultCode == Activity.RESULT_OK) {
+            val clipData = it.data?.clipData
+
+            if (clipData != null) {
+
+                val length = clipData.itemCount
+                val result = mutableListOf<Uri>()
+                for (i in 0 until length) {
+                    selectContact(clipData.getItemAt(i).uri, context)
+                }
+            } else {
+                val data = it.data?.data ?: return@rememberLauncherForActivityResult
+            }
+
+            // if (resultUris != mutableListOf<Uri>()) {
+            //     coroutine.launch {
+            //         selectContact(resultUris, context)
+            //     }
+            // }
+        }
+    }
+
     AnimatedVisibility(visible = shouldShowEmailAddressesFields(), modifier = modifier) {
         Column(verticalArrangement = Arrangement.spacedBy(textFieldSpacing)) {
             val isAuthorError = checkEmailError(isAuthor = true)
@@ -358,8 +414,35 @@ private fun EmailAddressesTextFields(
                 onValueChange = { recipientEmail.set(it.text) },
                 isError = isRecipientError,
                 supportingText = getEmailError(isRecipientError),
+                trailingIcon =
+                    {
+                        TrailingButton(
+                            AppIcons.PersonsCircleAdd,
+                            {
+                                try {
+                                    val pickContactIntent =
+                                        Intent(ACTION_PICK, ContactsContract.CommonDataKinds.Email.CONTENT_URI).apply {
+                                            putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+                                        }
+                                    pickContact.launch(pickContactIntent)
+                                } catch (_: ActivityNotFoundException) {
+                                    coroutine.launch {
+                                        longToast("The contact picker isn't available on your version of Android")
+                                    }
+                                }
+                            })
+                    },
             )
         }
+    }
+}
+
+@Composable
+private fun TrailingButton(appIcon: ImageVector, onClick: () -> Unit) {
+    IconButton(onClick = onClick) {
+        val (contentDescription, icon) = stringResource(R.string.contentDescriptionButtonHidePassword) to appIcon
+
+        Icon(icon, contentDescription, Modifier.size(Dimens.SmallIconSize))
     }
 }
 
@@ -546,6 +629,7 @@ private fun Preview(@PreviewParameter(UserListPreviewParameterProvider::class) u
                 selectedTransferType = GetSetCallbacks(get = { TransferTypeUi.Mail }, set = {}),
                 transferOptionsCallbacks = transferOptionsCallbacks,
                 pickFiles = {},
+                selectContact = { _, _ -> },
                 exitNewTransfer = {},
                 onSendButtonClick = {},
                 isAwaitingSend = { true },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -371,9 +371,7 @@ private fun EmailAddressesTextFields(
             val clipData = it.data?.clipData
 
             if (clipData != null) {
-
                 val length = clipData.itemCount
-                val result = mutableListOf<Uri>()
                 for (i in 0 until length) {
                     selectContact(clipData.getItemAt(i).uri, context)
                 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -28,6 +28,8 @@ import android.os.Build.VERSION.SDK_INT
 import android.provider.ContactsContract
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
@@ -257,9 +259,7 @@ private fun PickFilesScreen(
         modifier = Modifier.imePadding(),
         topBar = {
             SwissTransferTopAppBar(
-                titleRes = R.string.importFilesScreenTitle,
-                actions = { TopAppBarButtons.Close(onClick = { exitNewTransfer() }) }
-            )
+                titleRes = R.string.importFilesScreenTitle, actions = { TopAppBarButtons.Close(onClick = { exitNewTransfer() }) })
         },
         topButton = { modifier ->
             SendButton(
@@ -357,24 +357,42 @@ private fun EmailAddressesTextFields(
     val context = LocalContext.current
     val coroutine = rememberCoroutineScope()
 
-    val pickContact = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-        if (it.resultCode == Activity.RESULT_OK) {
-            val clipData = it.data?.clipData
+    fun buildPickEmailContactIntent(): Intent = Intent(ACTION_PICK, ContactsContract.CommonDataKinds.Email.CONTENT_URI).apply {
+        putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+    }
 
-            if (clipData != null) {
-                val length = clipData.itemCount
-                for (i in 0 until length) {
-                    clipData.getItemAt(i).uri?.let { uri ->
-                        selectContact(uri, context)
-                    }
+    fun handlePickedContacts(result: ActivityResult) {
+        if (result.resultCode != Activity.RESULT_OK) return
+
+        val dataIntent = result.data ?: return
+        val clipData = dataIntent.clipData
+
+        if (clipData != null) {
+            for (i in 0 until clipData.itemCount) {
+                clipData.getItemAt(i).uri?.let { uri ->
+                    selectContact(uri, context)
                 }
-            } else {
-                val data = it.data?.data ?: return@rememberLauncherForActivityResult
-                selectContact(data, context)
             }
+            return
+        }
 
+        dataIntent.data?.let { uri ->
+            selectContact(uri, context)
         }
     }
+
+    fun launchPickContactSafely(launcher: ActivityResultLauncher<Intent>) {
+        try {
+            launcher.launch(buildPickEmailContactIntent())
+        } catch (_: ActivityNotFoundException) {
+            coroutine.launch {
+                longToast(R.string.startActivityCantHandleAction)
+            }
+        }
+    }
+
+    val pickContactLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult(), ::handlePickedContacts)
 
     AnimatedVisibility(visible = shouldShowEmailAddressesFields(), modifier = modifier) {
         Column(verticalArrangement = Arrangement.spacedBy(textFieldSpacing)) {
@@ -402,24 +420,10 @@ private fun EmailAddressesTextFields(
                 onValueChange = { recipientEmail.set(it.text) },
                 isError = isRecipientError,
                 supportingText = getEmailError(isRecipientError),
-                trailingIcon =
-                    {
-                        TrailingButton(
-                            AppIcons.PersonsCircleAdd,
-                            {
-                                try {
-                                    val pickContactIntent =
-                                        Intent(ACTION_PICK, ContactsContract.CommonDataKinds.Email.CONTENT_URI).apply {
-                                            putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
-                                        }
-                                    pickContact.launch(pickContactIntent)
-                                } catch (_: ActivityNotFoundException) {
-                                    coroutine.launch {
-                                        longToast(R.string.startActivityCantHandleAction)
-                                    }
-                                }
-                            })
-                    },
+                trailingIcon = {
+                    TrailingButton(
+                        AppIcons.PersonsCircleAdd, onClick = { launchPickContactSafely(pickContactLauncher) })
+                },
             )
         }
     }
@@ -564,8 +568,7 @@ enum class PasswordTransferOption(
     override val imageVector: ImageVector? = null,
     override val imageVectorResId: Int? = null,
 ) : SettingOption {
-    NONE({ stringResource(R.string.settingsOptionNone) }),
-    ACTIVATED({ stringResource(R.string.settingsOptionActivated) }),
+    NONE({ stringResource(R.string.settingsOptionNone) }), ACTIVATED({ stringResource(R.string.settingsOptionActivated) }),
 }
 
 @PreviewAllWindows

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -33,9 +33,7 @@ import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
@@ -59,7 +57,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
@@ -85,16 +82,11 @@ import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.LocalUser
 import com.infomaniak.swisstransfer.ui.MatomoSwissTransfer
 import com.infomaniak.swisstransfer.ui.components.ButtonType
-import com.infomaniak.swisstransfer.ui.components.FabType
 import com.infomaniak.swisstransfer.ui.components.LargeButton
-import com.infomaniak.swisstransfer.ui.components.SwissTransferFab
 import com.infomaniak.swisstransfer.ui.components.SwissTransferTextField
 import com.infomaniak.swisstransfer.ui.components.SwissTransferTopAppBar
 import com.infomaniak.swisstransfer.ui.components.TopAppBarButtons
-import com.infomaniak.swisstransfer.ui.images.AppImages
 import com.infomaniak.swisstransfer.ui.images.AppImages.AppIcons
-import com.infomaniak.swisstransfer.ui.images.icons.EyeCrossed
-import com.infomaniak.swisstransfer.ui.images.icons.Person
 import com.infomaniak.swisstransfer.ui.images.icons.PersonsCircleAdd
 import com.infomaniak.swisstransfer.ui.previewparameter.filesPreviewData
 import com.infomaniak.swisstransfer.ui.screen.main.settings.DownloadLimitOption
@@ -117,7 +109,6 @@ import com.infomaniak.swisstransfer.upload.UploadForegroundService
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.selects.select
 import splitties.toast.longToast
 
 private val HORIZONTAL_PADDING = Margin.Medium
@@ -374,7 +365,7 @@ private fun EmailAddressesTextFields(
                 val length = clipData.itemCount
                 for (i in 0 until length) {
                     clipData.getItemAt(i).uri?.let { uri ->
-                        selectContact(uri,context)
+                        selectContact(uri, context)
                     }
                 }
             } else {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -424,7 +424,7 @@ private fun EmailAddressesTextFields(
                                     pickContact.launch(pickContactIntent)
                                 } catch (_: ActivityNotFoundException) {
                                     coroutine.launch {
-                                        longToast("The contact picker isn't available on your version of Android")
+                                        longToast(R.string.startActivityCantHandleAction)
                                     }
                                 }
                             })
@@ -437,7 +437,7 @@ private fun EmailAddressesTextFields(
 @Composable
 private fun TrailingButton(appIcon: ImageVector, onClick: () -> Unit) {
     IconButton(onClick = onClick) {
-        val (contentDescription, icon) = stringResource(R.string.contentDescriptionButtonHidePassword) to appIcon
+        val (contentDescription, icon) = stringResource(R.string.contentDescriptionButtonSelectContact) to appIcon
 
         Icon(icon, contentDescription, Modifier.size(Dimens.SmallIconSize))
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -117,6 +117,7 @@ import com.infomaniak.swisstransfer.upload.UploadForegroundService
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
 import splitties.toast.longToast
 
 private val HORIZONTAL_PADDING = Margin.Medium
@@ -378,13 +379,9 @@ private fun EmailAddressesTextFields(
                 }
             } else {
                 val data = it.data?.data ?: return@rememberLauncherForActivityResult
+                selectContact(data, context)
             }
 
-            // if (resultUris != mutableListOf<Uri>()) {
-            //     coroutine.launch {
-            //         selectContact(resultUris, context)
-            //     }
-            // }
         }
     }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -373,7 +373,9 @@ private fun EmailAddressesTextFields(
             if (clipData != null) {
                 val length = clipData.itemCount
                 for (i in 0 until length) {
-                    selectContact(clipData.getItemAt(i).uri, context)
+                    clipData.getItemAt(i).uri?.let { uri ->
+                        selectContact(uri,context)
+                    }
                 }
             } else {
                 val data = it.data?.data ?: return@rememberLauncherForActivityResult

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -359,7 +359,9 @@ private fun EmailAddressesTextFields(
             if (clipData != null) {
                 val length = clipData.itemCount
                 for (i in 0 until length) {
-                    selectContact(clipData.getItemAt(i).uri, context)
+                    clipData.getItemAt(i).uri?.let { uri ->
+                        selectContact(uri,context)
+                    }
                 }
             } else {
                 val data = it.data?.data ?: return@rememberLauncherForActivityResult

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -106,6 +106,7 @@ import com.infomaniak.swisstransfer.upload.UploadForegroundService
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
 import splitties.toast.longToast
 
 private val HORIZONTAL_PADDING = Margin.Medium
@@ -364,13 +365,9 @@ private fun EmailAddressesTextFields(
                 }
             } else {
                 val data = it.data?.data ?: return@rememberLauncherForActivityResult
+                selectContact(data, context)
             }
 
-            // if (resultUris != mutableListOf<Uri>()) {
-            //     coroutine.launch {
-            //         selectContact(resultUris, context)
-            //     }
-            // }
         }
     }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -237,7 +237,7 @@ private fun PickFilesScreen(
     selectedTransferType: GetSetCallbacks<TransferTypeUi>,
     transferOptionsCallbacks: TransferOptionsCallbacks,
     pickFiles: () -> Unit,
-    selectContact: (Uri, Context) -> Unit,
+    selectContact: (Uri) -> Unit,
     exitNewTransfer: () -> Unit,
     isAwaitingSend: () -> Boolean,
     onSendButtonClick: () -> Unit,
@@ -307,7 +307,7 @@ private fun ImportTextFields(
     emailTextFieldCallbacks: EmailTextFieldCallbacks,
     transferMessageCallbacks: GetSetCallbacks<String>,
     shouldShowEmailAddressesFields: () -> Boolean,
-    selectContact: (Uri, Context) -> Unit,
+    selectContact: (Uri) -> Unit,
 ) {
     val modifier = horizontalPaddingModifier.fillMaxWidth()
 
@@ -344,7 +344,7 @@ private fun EmailAddressesTextFields(
     emailTextFieldCallbacks: EmailTextFieldCallbacks,
     shouldShowEmailAddressesFields: () -> Boolean,
     textFieldSpacing: Dp,
-    selectContact: (Uri, Context) -> Unit,
+    selectContact: (Uri) -> Unit,
 ) = with(emailTextFieldCallbacks) {
     val context = LocalContext.current
 
@@ -361,14 +361,14 @@ private fun EmailAddressesTextFields(
         if (clipData != null) {
             for (i in 0 until clipData.itemCount) {
                 clipData.getItemAt(i).uri?.let { uri ->
-                    selectContact(uri, context)
+                    selectContact(uri)
                 }
             }
             return
         }
 
         dataIntent.data?.let { uri ->
-            selectContact(uri, context)
+            selectContact(uri)
         }
     }
 
@@ -609,7 +609,7 @@ private fun Preview(@PreviewParameter(UserListPreviewParameterProvider::class) u
                 selectedTransferType = GetSetCallbacks(get = { TransferTypeUi.Mail }, set = {}),
                 transferOptionsCallbacks = transferOptionsCallbacks,
                 pickFiles = {},
-                selectContact = { _, _ -> },
+                selectContact = { _ -> },
                 exitNewTransfer = {},
                 onSendButtonClick = {},
                 isAwaitingSend = { true },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -54,7 +54,6 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -107,7 +106,6 @@ import com.infomaniak.swisstransfer.ui.utils.isApiV2
 import com.infomaniak.swisstransfer.upload.UploadForegroundService
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.consumeEach
-import kotlinx.coroutines.launch
 import splitties.toast.longToast
 
 private val HORIZONTAL_PADDING = Margin.Medium
@@ -349,7 +347,6 @@ private fun EmailAddressesTextFields(
     selectContact: (Uri, Context) -> Unit,
 ) = with(emailTextFieldCallbacks) {
     val context = LocalContext.current
-    val coroutine = rememberCoroutineScope()
 
     fun buildPickEmailContactIntent(): Intent = Intent(ACTION_PICK, ContactsContract.CommonDataKinds.Email.CONTENT_URI).apply {
         putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
@@ -379,9 +376,7 @@ private fun EmailAddressesTextFields(
         try {
             launcher.launch(buildPickEmailContactIntent())
         } catch (_: ActivityNotFoundException) {
-            coroutine.launch {
-                longToast(R.string.startActivityCantHandleAction)
-            }
+            longToast(R.string.startActivityCantHandleAction)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -17,7 +17,13 @@
  */
 package com.infomaniak.swisstransfer.ui.screen.newtransfer.pickfiles
 
+import android.app.Activity
 import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.ACTION_PICK
+import android.net.Uri
+import android.provider.ContactsContract
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -30,8 +36,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -43,10 +52,12 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -72,6 +83,8 @@ import com.infomaniak.swisstransfer.ui.components.LargeButton
 import com.infomaniak.swisstransfer.ui.components.SwissTransferTextField
 import com.infomaniak.swisstransfer.ui.components.SwissTransferTopAppBar
 import com.infomaniak.swisstransfer.ui.components.TopAppBarButtons
+import com.infomaniak.swisstransfer.ui.images.AppImages.AppIcons
+import com.infomaniak.swisstransfer.ui.images.icons.PersonsCircleAdd
 import com.infomaniak.swisstransfer.ui.previewparameter.filesPreviewData
 import com.infomaniak.swisstransfer.ui.screen.main.settings.DownloadLimitOption
 import com.infomaniak.swisstransfer.ui.screen.main.settings.EmailLanguageOption
@@ -85,12 +98,14 @@ import com.infomaniak.swisstransfer.ui.screen.newtransfer.pickfiles.components.T
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.pickfiles.components.TransferOptionsTypes
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.pickfiles.components.TransferTypeButtons
 import com.infomaniak.swisstransfer.ui.screen.newtransfer.pickfiles.components.TransferTypeUi
+import com.infomaniak.swisstransfer.ui.theme.Dimens
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.GetSetCallbacks
 import com.infomaniak.swisstransfer.ui.utils.isApiV2
 import com.infomaniak.swisstransfer.upload.UploadForegroundService
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.launch
 import splitties.toast.longToast
 
 private val HORIZONTAL_PADDING = Margin.Medium
@@ -191,6 +206,7 @@ fun PickFilesScreen(
         ),
         transferOptionsCallbacks = transferOptionsCallbacks,
         pickFiles = ::pickFiles,
+        selectContact = pickFilesViewModel::processContactPickerResultUri,
         exitNewTransfer = { exit() },
         onSendButtonClick = {
             MatomoSwissTransfer.trackNewTransferDataEvent(pickFilesViewModel.selectedTransferTypeFlow.value.dbValue.matomoName)
@@ -221,6 +237,7 @@ private fun PickFilesScreen(
     selectedTransferType: GetSetCallbacks<TransferTypeUi>,
     transferOptionsCallbacks: TransferOptionsCallbacks,
     pickFiles: () -> Unit,
+    selectContact: (Uri, Context) -> Unit,
     exitNewTransfer: () -> Unit,
     isAwaitingSend: () -> Boolean,
     onSendButtonClick: () -> Unit,
@@ -258,6 +275,7 @@ private fun PickFilesScreen(
                     emailTextFieldCallbacks = emailTextFieldCallbacks,
                     transferMessageCallbacks = transferMessageCallbacks,
                     shouldShowEmailAddressesFields = { shouldShowEmailAddressesFields },
+                    selectContact = selectContact,
                 )
                 TransferOptions(modifier, transferOptionsCallbacks)
             }
@@ -291,6 +309,7 @@ private fun ImportTextFields(
     emailTextFieldCallbacks: EmailTextFieldCallbacks,
     transferMessageCallbacks: GetSetCallbacks<String>,
     shouldShowEmailAddressesFields: () -> Boolean,
+    selectContact: (Uri, Context) -> Unit,
 ) {
     val modifier = horizontalPaddingModifier.fillMaxWidth()
 
@@ -306,7 +325,9 @@ private fun ImportTextFields(
             )
         }
 
-        EmailAddressesTextFields(modifier, emailTextFieldCallbacks, shouldShowEmailAddressesFields, textFieldSpacing)
+        EmailAddressesTextFields(
+            modifier, emailTextFieldCallbacks, shouldShowEmailAddressesFields, textFieldSpacing, selectContact
+        )
 
         SwissTransferTextField(
             modifier = modifier,
@@ -325,7 +346,34 @@ private fun EmailAddressesTextFields(
     emailTextFieldCallbacks: EmailTextFieldCallbacks,
     shouldShowEmailAddressesFields: () -> Boolean,
     textFieldSpacing: Dp,
+    selectContact: (Uri, Context) -> Unit,
 ) = with(emailTextFieldCallbacks) {
+    val context = LocalContext.current
+    val coroutine = rememberCoroutineScope()
+
+    val pickContact = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        if (it.resultCode == Activity.RESULT_OK) {
+            val clipData = it.data?.clipData
+
+            if (clipData != null) {
+
+                val length = clipData.itemCount
+                val result = mutableListOf<Uri>()
+                for (i in 0 until length) {
+                    selectContact(clipData.getItemAt(i).uri, context)
+                }
+            } else {
+                val data = it.data?.data ?: return@rememberLauncherForActivityResult
+            }
+
+            // if (resultUris != mutableListOf<Uri>()) {
+            //     coroutine.launch {
+            //         selectContact(resultUris, context)
+            //     }
+            // }
+        }
+    }
+
     AnimatedVisibility(visible = shouldShowEmailAddressesFields(), modifier = modifier) {
         Column(verticalArrangement = Arrangement.spacedBy(textFieldSpacing)) {
             val isAuthorError = checkEmailError(isAuthor = true)
@@ -352,8 +400,35 @@ private fun EmailAddressesTextFields(
                 onValueChange = { recipientEmail.set(it.text) },
                 isError = isRecipientError,
                 supportingText = getEmailError(isRecipientError),
+                trailingIcon =
+                    {
+                        TrailingButton(
+                            AppIcons.PersonsCircleAdd,
+                            {
+                                try {
+                                    val pickContactIntent =
+                                        Intent(ACTION_PICK, ContactsContract.CommonDataKinds.Email.CONTENT_URI).apply {
+                                            putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+                                        }
+                                    pickContact.launch(pickContactIntent)
+                                } catch (_: ActivityNotFoundException) {
+                                    coroutine.launch {
+                                        longToast("The contact picker isn't available on your version of Android")
+                                    }
+                                }
+                            })
+                    },
             )
         }
+    }
+}
+
+@Composable
+private fun TrailingButton(appIcon: ImageVector, onClick: () -> Unit) {
+    IconButton(onClick = onClick) {
+        val (contentDescription, icon) = stringResource(R.string.contentDescriptionButtonHidePassword) to appIcon
+
+        Icon(icon, contentDescription, Modifier.size(Dimens.SmallIconSize))
     }
 }
 
@@ -540,6 +615,7 @@ private fun Preview(@PreviewParameter(UserListPreviewParameterProvider::class) u
                 selectedTransferType = GetSetCallbacks(get = { TransferTypeUi.Mail }, set = {}),
                 transferOptionsCallbacks = transferOptionsCallbacks,
                 pickFiles = {},
+                selectContact = { _, _ -> },
                 exitNewTransfer = {},
                 onSendButtonClick = {},
                 isAwaitingSend = { true },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -26,6 +26,8 @@ import android.net.Uri
 import android.provider.ContactsContract
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
@@ -251,9 +253,7 @@ private fun PickFilesScreen(
         modifier = Modifier.imePadding(),
         topBar = {
             SwissTransferTopAppBar(
-                titleRes = R.string.importFilesScreenTitle,
-                actions = { TopAppBarButtons.Close(onClick = { exitNewTransfer() }) }
-            )
+                titleRes = R.string.importFilesScreenTitle, actions = { TopAppBarButtons.Close(onClick = { exitNewTransfer() }) })
         },
         topButton = { modifier ->
             SendButton(
@@ -351,24 +351,42 @@ private fun EmailAddressesTextFields(
     val context = LocalContext.current
     val coroutine = rememberCoroutineScope()
 
-    val pickContact = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-        if (it.resultCode == Activity.RESULT_OK) {
-            val clipData = it.data?.clipData
+    fun buildPickEmailContactIntent(): Intent = Intent(ACTION_PICK, ContactsContract.CommonDataKinds.Email.CONTENT_URI).apply {
+        putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+    }
 
-            if (clipData != null) {
-                val length = clipData.itemCount
-                for (i in 0 until length) {
-                    clipData.getItemAt(i).uri?.let { uri ->
-                        selectContact(uri, context)
-                    }
+    fun handlePickedContacts(result: ActivityResult) {
+        if (result.resultCode != Activity.RESULT_OK) return
+
+        val dataIntent = result.data ?: return
+        val clipData = dataIntent.clipData
+
+        if (clipData != null) {
+            for (i in 0 until clipData.itemCount) {
+                clipData.getItemAt(i).uri?.let { uri ->
+                    selectContact(uri, context)
                 }
-            } else {
-                val data = it.data?.data ?: return@rememberLauncherForActivityResult
-                selectContact(data, context)
             }
+            return
+        }
 
+        dataIntent.data?.let { uri ->
+            selectContact(uri, context)
         }
     }
+
+    fun launchPickContactSafely(launcher: ActivityResultLauncher<Intent>) {
+        try {
+            launcher.launch(buildPickEmailContactIntent())
+        } catch (_: ActivityNotFoundException) {
+            coroutine.launch {
+                longToast(R.string.startActivityCantHandleAction)
+            }
+        }
+    }
+
+    val pickContactLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult(), ::handlePickedContacts)
 
     AnimatedVisibility(visible = shouldShowEmailAddressesFields(), modifier = modifier) {
         Column(verticalArrangement = Arrangement.spacedBy(textFieldSpacing)) {
@@ -396,24 +414,10 @@ private fun EmailAddressesTextFields(
                 onValueChange = { recipientEmail.set(it.text) },
                 isError = isRecipientError,
                 supportingText = getEmailError(isRecipientError),
-                trailingIcon =
-                    {
-                        TrailingButton(
-                            AppIcons.PersonsCircleAdd,
-                            {
-                                try {
-                                    val pickContactIntent =
-                                        Intent(ACTION_PICK, ContactsContract.CommonDataKinds.Email.CONTENT_URI).apply {
-                                            putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
-                                        }
-                                    pickContact.launch(pickContactIntent)
-                                } catch (_: ActivityNotFoundException) {
-                                    coroutine.launch {
-                                        longToast(R.string.startActivityCantHandleAction)
-                                    }
-                                }
-                            })
-                    },
+                trailingIcon = {
+                    TrailingButton(
+                        AppIcons.PersonsCircleAdd, onClick = { launchPickContactSafely(pickContactLauncher) })
+                },
             )
         }
     }
@@ -558,8 +562,7 @@ enum class PasswordTransferOption(
     override val imageVector: ImageVector? = null,
     override val imageVectorResId: Int? = null,
 ) : SettingOption {
-    NONE({ stringResource(R.string.settingsOptionNone) }),
-    ACTIVATED({ stringResource(R.string.settingsOptionActivated) }),
+    NONE({ stringResource(R.string.settingsOptionNone) }), ACTIVATED({ stringResource(R.string.settingsOptionActivated) }),
 }
 
 @PreviewAllWindows

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -106,7 +106,6 @@ import com.infomaniak.swisstransfer.upload.UploadForegroundService
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.selects.select
 import splitties.toast.longToast
 
 private val HORIZONTAL_PADDING = Margin.Medium
@@ -360,7 +359,7 @@ private fun EmailAddressesTextFields(
                 val length = clipData.itemCount
                 for (i in 0 until length) {
                     clipData.getItemAt(i).uri?.let { uri ->
-                        selectContact(uri,context)
+                        selectContact(uri, context)
                     }
                 }
             } else {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -106,6 +107,7 @@ import com.infomaniak.swisstransfer.ui.utils.showToast
 import com.infomaniak.swisstransfer.upload.UploadForegroundService
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.launch
 
 private val HORIZONTAL_PADDING = Margin.Medium
 
@@ -276,6 +278,7 @@ private fun PickFilesScreen(
                     transferMessageCallbacks = transferMessageCallbacks,
                     shouldShowEmailAddressesFields = { shouldShowEmailAddressesFields },
                     selectContact = selectContact,
+                    snackbarHostState = snackbarHostState
                 )
                 TransferOptions(modifier, transferOptionsCallbacks)
             }
@@ -310,6 +313,7 @@ private fun ImportTextFields(
     transferMessageCallbacks: GetSetCallbacks<String>,
     shouldShowEmailAddressesFields: () -> Boolean,
     selectContact: (Uri) -> Unit,
+    snackbarHostState: SnackbarHostState?
 ) {
     val modifier = horizontalPaddingModifier.fillMaxWidth()
 
@@ -350,16 +354,22 @@ private fun EmailAddressesTextFields(
     shouldShowEmailAddressesFields: () -> Boolean,
     textFieldSpacing: Dp,
     selectContact: (Uri) -> Unit,
+    snackbarHostState: SnackbarHostState?,
     modifier: Modifier = Modifier,
 ) = with(emailTextFieldCallbacks) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val contactRetreivalError = stringResource(R.string.errorContactPicker)
 
     fun buildPickEmailContactIntent(): Intent = Intent(ACTION_PICK, Email.CONTENT_URI).apply {
         putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
     }
 
     fun handlePickedContacts(result: ActivityResult) {
-        if (result.resultCode != Activity.RESULT_OK) return
+        if (result.resultCode != Activity.RESULT_OK || result.data == null) {
+            scope.launch { snackbarHostState?.showSnackbar(contactRetreivalError) }
+            return
+        }
         val dataIntent = result.data ?: return
 
         dataIntent.clipData?.let { clipData ->

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -243,7 +243,7 @@ private fun PickFilesScreen(
     exitNewTransfer: () -> Unit,
     isAwaitingSend: () -> Boolean,
     onSendButtonClick: () -> Unit,
-    snackbarHostState: SnackbarHostState? = null,
+    snackbarHostState: SnackbarHostState,
     navigateToFilesDetails: () -> Unit,
 ) {
 
@@ -309,11 +309,11 @@ private fun FilesToImport(
 private fun ImportTextFields(
     horizontalPaddingModifier: Modifier,
     transferTitleState: MutableState<String>,
+    snackbarHostState: SnackbarHostState,
     emailTextFieldCallbacks: EmailTextFieldCallbacks,
     transferMessageCallbacks: GetSetCallbacks<String>,
     shouldShowEmailAddressesFields: () -> Boolean,
     selectContact: (Uri) -> Unit,
-    snackbarHostState: SnackbarHostState?
 ) {
     val modifier = horizontalPaddingModifier.fillMaxWidth()
 
@@ -334,6 +334,7 @@ private fun ImportTextFields(
             shouldShowEmailAddressesFields = shouldShowEmailAddressesFields,
             textFieldSpacing = textFieldSpacing,
             selectContact = selectContact,
+            snackbarHostState = snackbarHostState,
             modifier = modifier,
         )
 
@@ -354,7 +355,7 @@ private fun EmailAddressesTextFields(
     shouldShowEmailAddressesFields: () -> Boolean,
     textFieldSpacing: Dp,
     selectContact: (Uri) -> Unit,
-    snackbarHostState: SnackbarHostState?,
+    snackbarHostState: SnackbarHostState,
     modifier: Modifier = Modifier,
 ) = with(emailTextFieldCallbacks) {
     val context = LocalContext.current
@@ -367,7 +368,7 @@ private fun EmailAddressesTextFields(
 
     fun handlePickedContacts(result: ActivityResult) {
         if (result.resultCode != Activity.RESULT_OK || result.data == null) {
-            scope.launch { snackbarHostState?.showSnackbar(contactRetreivalError) }
+            scope.launch { snackbarHostState.showSnackbar(contactRetreivalError) }
             return
         }
         val dataIntent = result.data ?: return
@@ -625,6 +626,7 @@ private fun Preview(@PreviewParameter(UserListPreviewParameterProvider::class) u
                 onSendButtonClick = {},
                 isAwaitingSend = { true },
                 navigateToFilesDetails = {},
+                snackbarHostState = remember { SnackbarHostState() }
             )
         }
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -19,11 +19,10 @@ package com.infomaniak.swisstransfer.ui.screen.newtransfer.pickfiles
 
 import android.app.Activity
 import android.content.ActivityNotFoundException
-import android.content.Context
 import android.content.Intent
 import android.content.Intent.ACTION_PICK
 import android.net.Uri
-import android.provider.ContactsContract
+import android.provider.ContactsContract.CommonDataKinds.Email
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResult
@@ -103,10 +102,10 @@ import com.infomaniak.swisstransfer.ui.theme.Dimens
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.GetSetCallbacks
 import com.infomaniak.swisstransfer.ui.utils.isApiV2
+import com.infomaniak.swisstransfer.ui.utils.showToast
 import com.infomaniak.swisstransfer.upload.UploadForegroundService
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.consumeEach
-import splitties.toast.longToast
 
 private val HORIZONTAL_PADDING = Margin.Medium
 
@@ -119,6 +118,7 @@ fun PickFilesScreen(
     navigateToFilesDetails: () -> Unit,
     notificationPermissionManager: RationalePermissionManagerState,
 ) {
+    val context = LocalContext.current
 
     val files by pickFilesViewModel.importedFilesDebounced.collectAsStateWithLifecycle()
     val canSendStatus: CanSendStatus by pickFilesViewModel.canSendStatusFlow.collectAsState()
@@ -139,7 +139,7 @@ fun PickFilesScreen(
         try {
             filePickerLauncher.launch(arrayOf("*/*"))
         } catch (e: ActivityNotFoundException) {
-            longToast(R.string.startActivityCantHandleAction)
+            context.showToast(R.string.startActivityCantHandleAction)
         }
     }
 
@@ -324,7 +324,11 @@ private fun ImportTextFields(
         }
 
         EmailAddressesTextFields(
-            modifier, emailTextFieldCallbacks, shouldShowEmailAddressesFields, textFieldSpacing, selectContact
+            modifier = modifier,
+            emailTextFieldCallbacks = emailTextFieldCallbacks,
+            shouldShowEmailAddressesFields = shouldShowEmailAddressesFields,
+            textFieldSpacing = textFieldSpacing,
+            selectContact = selectContact
         )
 
         SwissTransferTextField(
@@ -347,41 +351,33 @@ private fun EmailAddressesTextFields(
     selectContact: (Uri) -> Unit,
 ) = with(emailTextFieldCallbacks) {
     val context = LocalContext.current
-
-    fun buildPickEmailContactIntent(): Intent = Intent(ACTION_PICK, ContactsContract.CommonDataKinds.Email.CONTENT_URI).apply {
+    fun buildPickEmailContactIntent(): Intent = Intent(ACTION_PICK, Email.CONTENT_URI).apply {
         putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
     }
 
     fun handlePickedContacts(result: ActivityResult) {
         if (result.resultCode != Activity.RESULT_OK) return
-
         val dataIntent = result.data ?: return
-        val clipData = dataIntent.clipData
 
-        if (clipData != null) {
+        dataIntent.clipData?.let { clipData ->
             for (i in 0 until clipData.itemCount) {
-                clipData.getItemAt(i).uri?.let { uri ->
-                    selectContact(uri)
-                }
+                clipData.getItemAt(i).uri?.let { uri -> selectContact(uri) }
             }
-            return
-        }
-
-        dataIntent.data?.let { uri ->
-            selectContact(uri)
-        }
+        } ?: dataIntent.data?.let { uri -> selectContact(uri) }
     }
 
     fun launchPickContactSafely(launcher: ActivityResultLauncher<Intent>) {
         try {
             launcher.launch(buildPickEmailContactIntent())
         } catch (_: ActivityNotFoundException) {
-            longToast(R.string.startActivityCantHandleAction)
+            context.showToast(R.string.startActivityCantHandleAction)
         }
     }
 
-    val pickContactLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult(), ::handlePickedContacts)
+    val pickContactLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult(),
+        onResult = ::handlePickedContacts,
+    )
 
     AnimatedVisibility(visible = shouldShowEmailAddressesFields(), modifier = modifier) {
         Column(verticalArrangement = Arrangement.spacedBy(textFieldSpacing)) {
@@ -410,8 +406,9 @@ private fun EmailAddressesTextFields(
                 isError = isRecipientError,
                 supportingText = getEmailError(isRecipientError),
                 trailingIcon = {
-                    TrailingButton(
-                        AppIcons.PersonsCircleAdd, onClick = { launchPickContactSafely(pickContactLauncher) })
+                    TrailingButton(AppIcons.PersonsCircleAdd, onClick = {
+                        launchPickContactSafely(pickContactLauncher)
+                    }, R.string.contentDescriptionButtonSelectContact)
                 },
             )
         }
@@ -419,11 +416,9 @@ private fun EmailAddressesTextFields(
 }
 
 @Composable
-private fun TrailingButton(appIcon: ImageVector, onClick: () -> Unit) {
+private fun TrailingButton(appIcon: ImageVector, onClick: () -> Unit, contentDescription: Int) {
     IconButton(onClick = onClick) {
-        val (contentDescription, icon) = stringResource(R.string.contentDescriptionButtonSelectContact) to appIcon
-
-        Icon(icon, contentDescription, Modifier.size(Dimens.SmallIconSize))
+        Icon(appIcon, stringResource(contentDescription), Modifier.size(Dimens.SmallIconSize))
     }
 }
 
@@ -557,7 +552,8 @@ enum class PasswordTransferOption(
     override val imageVector: ImageVector? = null,
     override val imageVectorResId: Int? = null,
 ) : SettingOption {
-    NONE({ stringResource(R.string.settingsOptionNone) }), ACTIVATED({ stringResource(R.string.settingsOptionActivated) }),
+    NONE({ stringResource(R.string.settingsOptionNone) }),
+    ACTIVATED({ stringResource(R.string.settingsOptionActivated) }),
 }
 
 @PreviewAllWindows
@@ -609,7 +605,7 @@ private fun Preview(@PreviewParameter(UserListPreviewParameterProvider::class) u
                 selectedTransferType = GetSetCallbacks(get = { TransferTypeUi.Mail }, set = {}),
                 transferOptionsCallbacks = transferOptionsCallbacks,
                 pickFiles = {},
-                selectContact = { _ -> },
+                selectContact = {},
                 exitNewTransfer = {},
                 onSendButtonClick = {},
                 isAwaitingSend = { true },

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -416,9 +416,9 @@ private fun EmailAddressesTextFields(
 }
 
 @Composable
-private fun TrailingButton(appIcon: ImageVector, onClick: () -> Unit, contentDescription: Int) {
+private fun TrailingButton(appIcon: ImageVector, onClick: () -> Unit, @StringRes contentDescriptionRes: Int) {
     IconButton(onClick = onClick) {
-        Icon(appIcon, stringResource(contentDescription), Modifier.size(Dimens.SmallIconSize))
+        Icon(appIcon, stringResource(contentDescriptionRes), Modifier.size(Dimens.SmallIconSize))
     }
 }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -410,7 +410,7 @@ private fun EmailAddressesTextFields(
                                     pickContact.launch(pickContactIntent)
                                 } catch (_: ActivityNotFoundException) {
                                     coroutine.launch {
-                                        longToast("The contact picker isn't available on your version of Android")
+                                        longToast(R.string.startActivityCantHandleAction)
                                     }
                                 }
                             })
@@ -423,7 +423,7 @@ private fun EmailAddressesTextFields(
 @Composable
 private fun TrailingButton(appIcon: ImageVector, onClick: () -> Unit) {
     IconButton(onClick = onClick) {
-        val (contentDescription, icon) = stringResource(R.string.contentDescriptionButtonHidePassword) to appIcon
+        val (contentDescription, icon) = stringResource(R.string.contentDescriptionButtonSelectContact) to appIcon
 
         Icon(icon, contentDescription, Modifier.size(Dimens.SmallIconSize))
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak SwissTransfer - Android
- * Copyright (C) 2024-2025 Infomaniak Network SA
+ * Copyright (C) 2024-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -326,11 +326,11 @@ private fun ImportTextFields(
         }
 
         EmailAddressesTextFields(
-            modifier = modifier,
             emailTextFieldCallbacks = emailTextFieldCallbacks,
             shouldShowEmailAddressesFields = shouldShowEmailAddressesFields,
             textFieldSpacing = textFieldSpacing,
-            selectContact = selectContact
+            selectContact = selectContact,
+            modifier = modifier,
         )
 
         SwissTransferTextField(
@@ -346,13 +346,14 @@ private fun ImportTextFields(
 
 @Composable
 private fun EmailAddressesTextFields(
-    modifier: Modifier,
     emailTextFieldCallbacks: EmailTextFieldCallbacks,
     shouldShowEmailAddressesFields: () -> Boolean,
     textFieldSpacing: Dp,
     selectContact: (Uri) -> Unit,
+    modifier: Modifier = Modifier,
 ) = with(emailTextFieldCallbacks) {
     val context = LocalContext.current
+
     fun buildPickEmailContactIntent(): Intent = Intent(ACTION_PICK, Email.CONTENT_URI).apply {
         putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
     }
@@ -409,9 +410,9 @@ private fun EmailAddressesTextFields(
                 supportingText = getEmailError(isRecipientError),
                 trailingIcon = {
                     TrailingButton(
-                        AppIcons.PersonsCircleAdd,
+                        appIcon = AppIcons.PersonsCircleAdd,
                         onClick = { launchPickContactSafely(pickContactLauncher) },
-                        R.string.contentDescriptionButtonSelectContact
+                        contentDescriptionRes = R.string.contentDescriptionButtonSelectContact
                     )
                 },
             )

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -251,7 +251,9 @@ private fun PickFilesScreen(
         modifier = Modifier.imePadding(),
         topBar = {
             SwissTransferTopAppBar(
-                titleRes = R.string.importFilesScreenTitle, actions = { TopAppBarButtons.Close(onClick = { exitNewTransfer() }) })
+                titleRes = R.string.importFilesScreenTitle,
+                actions = { TopAppBarButtons.Close(onClick = { exitNewTransfer() }) }
+            )
         },
         topButton = { modifier ->
             SendButton(
@@ -406,9 +408,11 @@ private fun EmailAddressesTextFields(
                 isError = isRecipientError,
                 supportingText = getEmailError(isRecipientError),
                 trailingIcon = {
-                    TrailingButton(AppIcons.PersonsCircleAdd, onClick = {
-                        launchPickContactSafely(pickContactLauncher)
-                    }, R.string.contentDescriptionButtonSelectContact)
+                    TrailingButton(
+                        AppIcons.PersonsCircleAdd,
+                        onClick = { launchPickContactSafely(pickContactLauncher) },
+                        R.string.contentDescriptionButtonSelectContact
+                    )
                 },
             )
         }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesScreen.kt
@@ -357,9 +357,7 @@ private fun EmailAddressesTextFields(
             val clipData = it.data?.clipData
 
             if (clipData != null) {
-
                 val length = clipData.itemCount
-                val result = mutableListOf<Uri>()
                 for (i in 0 until length) {
                     selectContact(clipData.getItemAt(i).uri, context)
                 }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
@@ -20,7 +20,9 @@
 
 package com.infomaniak.swisstransfer.ui.screen.newtransfer.pickfiles
 
+import android.content.Context
 import android.net.Uri
+import android.provider.ContactsContract
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -60,6 +62,7 @@ import com.infomaniak.swisstransfer.upload.NewTransferParams
 import com.infomaniak.swisstransfer.upload.UploadForegroundService
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
@@ -73,9 +76,12 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import splitties.coroutines.repeatWhileActive
 import splitties.experimental.ExperimentalSplittiesApi
 import javax.inject.Inject
+import kotlin.collections.mutableListOf
+import kotlin.collections.set
 
 @HiltViewModel
 class PickFilesViewModel @Inject constructor(
@@ -404,6 +410,66 @@ class PickFilesViewModel @Inject constructor(
             is EmailLanguageOption -> selectTransferLanguage(option)
         }
     }
+
+    data class Contact(
+        val lookupKey: String,
+        val emails: List<String>,
+    )
+
+    fun processContactPickerResultUri(
+        sessionUris: Uri,
+        context: Context,
+    ) {
+        viewModelScope.launch { contactPickLaunch(sessionUris, context) }
+    }
+
+    private suspend fun contactPickLaunch(
+        sessionUris: Uri,
+        context: Context,
+    ) = withContext(Dispatchers.IO) {
+        val projection = arrayOf(
+            ContactsContract.Contacts.LOOKUP_KEY,
+            ContactsContract.Data.MIMETYPE,
+            ContactsContract.Data.DATA1,
+        )
+
+        val contactsMap = mutableMapOf<String, Contact>()
+
+        context.contentResolver.query(sessionUris, projection, null, null, null)?.use { cursor ->
+            val lookupKeyIdx = cursor.getColumnIndex(ContactsContract.Contacts.LOOKUP_KEY)
+            val mimeTypeIdx = cursor.getColumnIndex(ContactsContract.Data.MIMETYPE)
+            val data1Idx = cursor.getColumnIndex(ContactsContract.Data.DATA1)
+
+            while (cursor.moveToNext()) {
+                val lookupKey = cursor.getString(lookupKeyIdx)
+                val mimeType = cursor.getString(mimeTypeIdx)
+                val data1 = cursor.getString(data1Idx) ?: ""
+
+                val email = if (mimeType == ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE) data1 else null
+
+                val existingContact = contactsMap[lookupKey]
+                if (existingContact != null) {
+                    contactsMap[lookupKey] = existingContact.copy(
+                        emails = if (email != null) existingContact.emails + email else existingContact.emails,
+                    )
+                } else {
+                    contactsMap[lookupKey] = Contact(
+                        lookupKey = lookupKey,
+                        emails = if (email != null) listOf(email) else emptyList(),
+                    )
+                }
+            }
+        }
+
+        val iterator = contactsMap.entries.iterator()
+        while (iterator.hasNext()) {
+            val (key, value) = iterator.next()
+            validatedRecipientsEmails = validatedRecipientsEmails.plus(value.emails)
+
+        }
+
+    }
+
 //endregion
 
     companion object {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
@@ -21,6 +21,7 @@
 package com.infomaniak.swisstransfer.ui.screen.newtransfer.pickfiles
 
 import android.content.Context
+import android.database.Cursor
 import android.net.Uri
 import android.provider.ContactsContract
 import androidx.compose.runtime.derivedStateOf
@@ -80,8 +81,6 @@ import kotlinx.coroutines.withContext
 import splitties.coroutines.repeatWhileActive
 import splitties.experimental.ExperimentalSplittiesApi
 import javax.inject.Inject
-import kotlin.collections.mutableListOf
-import kotlin.collections.set
 
 @HiltViewModel
 class PickFilesViewModel @Inject constructor(
@@ -134,9 +133,7 @@ class PickFilesViewModel @Inject constructor(
             }
 
             enum class Email : Issue {
-                AuthorUnspecified,
-                AuthorInvalid,
-                NoValidatedRecipients,
+                AuthorUnspecified, AuthorInvalid, NoValidatedRecipients,
             }
         }
     }
@@ -196,8 +193,7 @@ class PickFilesViewModel @Inject constructor(
             initialValue = FilesDetailsUiState.Success(emptyList()),
         )
 
-        @OptIn(FlowPreview::class)
-        importedFilesDebounced = pickedFilesFlow.debounce(50).stateIn(
+        @OptIn(FlowPreview::class) importedFilesDebounced = pickedFilesFlow.debounce(50).stateIn(
             scope = viewModelScope,
             started = SharingStarted.Lazily,
             initialValue = emptyList(),
@@ -256,8 +252,7 @@ class PickFilesViewModel @Inject constructor(
     }
 
     private fun pickedFilesIssues(
-        maxFilesSize: Long = FileUtils.MAX_FILES_SIZE,
-        maxFilesCount: Int = FileUtils.MAX_FILE_COUNT
+        maxFilesSize: Long = FileUtils.MAX_FILES_SIZE, maxFilesCount: Int = FileUtils.MAX_FILE_COUNT
     ): StateFlow<Set<Issue>> = UploadForegroundService.pickedFilesFlow.mapSync { pickedFiles ->
         if (pickedFiles.isEmpty()) {
             setOf(Issue.Files.NonePicked)
@@ -326,8 +321,7 @@ class PickFilesViewModel @Inject constructor(
 
     //region Transfer Options
     val selectedValidityPeriodOption = savedStateHandle.getStateFlow(
-        key = SELECTED_VALIDITY_PERIOD_KEY,
-        initialValue = ValidityPeriodOption.THIRTY
+        key = SELECTED_VALIDITY_PERIOD_KEY, initialValue = ValidityPeriodOption.THIRTY
     )
 
     val selectedDownloadLimitOption = savedStateHandle.getStateFlow(
@@ -422,7 +416,7 @@ class PickFilesViewModel @Inject constructor(
     ) {
         try {
             viewModelScope.launch { contactPickLaunch(sessionUris, context) }
-        }catch (e: Exception){
+        } catch (e: Exception) {
             SentryLog.e(TAG, "Error while importing contacts from picker result", e)
         }
     }
@@ -430,7 +424,17 @@ class PickFilesViewModel @Inject constructor(
     private suspend fun contactPickLaunch(
         sessionUris: Uri,
         context: Context,
-    ) = withContext(Dispatchers.IO) {
+    ) {
+        val contacts = queryContacts(sessionUris, context)
+        val newEmails = contacts.values.asSequence().flatMap { it.emails.asSequence() }.toSet()
+
+        updateValidatedRecipientsEmails(newEmails)
+    }
+
+    private suspend fun queryContacts(
+        sessionUris: Uri,
+        context: Context,
+    ): Map<String, Contact> = withContext(Dispatchers.IO) {
         val projection = arrayOf(
             ContactsContract.Contacts.LOOKUP_KEY,
             ContactsContract.Data.MIMETYPE,
@@ -440,43 +444,55 @@ class PickFilesViewModel @Inject constructor(
         val contactsMap = mutableMapOf<String, Contact>()
 
         context.contentResolver.query(sessionUris, projection, null, null, null)?.use { cursor ->
-            val lookupKeyIdx = cursor.getColumnIndex(ContactsContract.Contacts.LOOKUP_KEY)
-            val mimeTypeIdx = cursor.getColumnIndex(ContactsContract.Data.MIMETYPE)
-            val data1Idx = cursor.getColumnIndex(ContactsContract.Data.DATA1)
-
-            if (lookupKeyIdx == -1 || mimeTypeIdx == -1 || data1Idx == -1) {
+            val indices = cursor.contactProjectionIndicesOrNull()
+            if (indices == null) {
                 SentryLog.e(TAG, "Projection invalide, colonnes manquantes.")
                 return@use
             }
 
             while (cursor.moveToNext()) {
-                val lookupKey = cursor.getString(lookupKeyIdx)
-                val mimeType = cursor.getString(mimeTypeIdx)
-                val data1 = cursor.getString(data1Idx) ?: ""
+                val lookupKey = cursor.getString(indices.lookupKeyIdx)
+                val email = cursor.emailOrNull(indices.mimeTypeIdx, indices.data1Idx) ?: continue
 
-                val email = if (mimeType == ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE) data1 else null
-
-                val existingContact = contactsMap[lookupKey]
-                if (existingContact != null) {
-                    contactsMap[lookupKey] = existingContact.copy(
-                        emails = if (email != null) existingContact.emails + email else existingContact.emails,
-                    )
-                } else {
-                    contactsMap[lookupKey] = Contact(
-                        lookupKey = lookupKey,
-                        emails = if (email != null) listOf(email) else emptyList(),
-                    )
-                }
+                val current = contactsMap[lookupKey] ?: Contact(lookupKey = lookupKey, emails = emptyList())
+                contactsMap[lookupKey] = current.copy(emails = current.emails + email)
             }
         }
-
-        withContext(Dispatchers.Main) {
-            val allNewEmails = contactsMap.values.flatMap { it.emails }.toSet()
-            validatedRecipientsEmails = validatedRecipientsEmails.plus(allNewEmails)
-        }
-
+        contactsMap
     }
 
+    private suspend fun updateValidatedRecipientsEmails(newEmails: Set<String>) = withContext(Dispatchers.Main) {
+        validatedRecipientsEmails = validatedRecipientsEmails + newEmails
+    }
+
+    private data class ContactProjectionIndices(
+        val lookupKeyIdx: Int,
+        val mimeTypeIdx: Int,
+        val data1Idx: Int,
+    )
+
+    private fun Cursor.contactProjectionIndicesOrNull(): ContactProjectionIndices? {
+        val lookupKeyIdx = getColumnIndex(ContactsContract.Contacts.LOOKUP_KEY)
+        val mimeTypeIdx = getColumnIndex(ContactsContract.Data.MIMETYPE)
+        val data1Idx = getColumnIndex(ContactsContract.Data.DATA1)
+
+        return if (lookupKeyIdx == -1 || mimeTypeIdx == -1 || data1Idx == -1) {
+            null
+        } else {
+            ContactProjectionIndices(
+                lookupKeyIdx = lookupKeyIdx,
+                mimeTypeIdx = mimeTypeIdx,
+                data1Idx = data1Idx,
+            )
+        }
+    }
+
+    private fun Cursor.emailOrNull(mimeTypeIdx: Int, data1Idx: Int): String? {
+        val mimeType = getString(mimeTypeIdx)
+        if (mimeType != ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE) return null
+
+        return getString(data1Idx)
+    }
 //endregion
 
     companion object {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
@@ -423,7 +423,7 @@ class PickFilesViewModel @Inject constructor(
         try {
             viewModelScope.launch { contactPickLaunch(sessionUris, context) }
         }catch (e: Exception){
-            SentryLog.e(TAG, "Error while launching contact picker", e)
+            SentryLog.e(TAG, "Error while importing contacts from picker result", e)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
@@ -420,7 +420,11 @@ class PickFilesViewModel @Inject constructor(
         sessionUris: Uri,
         context: Context,
     ) {
-        viewModelScope.launch { contactPickLaunch(sessionUris, context) }
+        try {
+            viewModelScope.launch { contactPickLaunch(sessionUris, context) }
+        }catch (e: Exception){
+            SentryLog.e(TAG, "Error while launching contact picker", e)
+        }
     }
 
     private suspend fun contactPickLaunch(
@@ -461,11 +465,9 @@ class PickFilesViewModel @Inject constructor(
             }
         }
 
-        val iterator = contactsMap.entries.iterator()
-        while (iterator.hasNext()) {
-            val (key, value) = iterator.next()
-            validatedRecipientsEmails = validatedRecipientsEmails.plus(value.emails)
-
+        withContext(Dispatchers.Main) {
+            val allNewEmails = contactsMap.values.flatMap { it.emails }.toSet()
+            validatedRecipientsEmails = validatedRecipientsEmails.plus(allNewEmails)
         }
 
     }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
@@ -444,6 +444,11 @@ class PickFilesViewModel @Inject constructor(
             val mimeTypeIdx = cursor.getColumnIndex(ContactsContract.Data.MIMETYPE)
             val data1Idx = cursor.getColumnIndex(ContactsContract.Data.DATA1)
 
+            if (lookupKeyIdx == -1 || mimeTypeIdx == -1 || data1Idx == -1) {
+                SentryLog.e(TAG, "Projection invalide, colonnes manquantes.")
+                return@use
+            }
+
             while (cursor.moveToNext()) {
                 val lookupKey = cursor.getString(lookupKeyIdx)
                 val mimeType = cursor.getString(mimeTypeIdx)

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
@@ -405,36 +405,36 @@ class PickFilesViewModel @Inject constructor(
         }
     }
 
-    data class Contact(
+    private data class Contact(
         val lookupKey: String,
         val emails: List<String>,
     )
 
     fun processContactPickerResultUri(
-        sessionUris: Uri,
+        sessionUri: Uri,
         context: Context,
     ) {
         try {
-            viewModelScope.launch { contactPickLaunch(sessionUris, context) }
+            viewModelScope.launch { contactPickLaunch(sessionUri, context) }
         } catch (e: Exception) {
             SentryLog.e(TAG, "Error while importing contacts from picker result", e)
         }
     }
 
     private suspend fun contactPickLaunch(
-        sessionUris: Uri,
+        sessionUri: Uri,
         context: Context,
     ) {
-        val contacts = queryContacts(sessionUris, context)
+        val contacts = queryContacts(sessionUri, context)
         val newEmails = contacts.values.asSequence().flatMap { it.emails.asSequence() }.toSet()
 
         updateValidatedRecipientsEmails(newEmails)
     }
 
     private suspend fun queryContacts(
-        sessionUris: Uri,
+        sessionUri: Uri,
         context: Context,
-    ): Map<String, Contact> = withContext(Dispatchers.IO) {
+    ): Map<String, Contact> = withContext(ioDispatcher) {
         val projection = arrayOf(
             ContactsContract.Contacts.LOOKUP_KEY,
             ContactsContract.Data.MIMETYPE,
@@ -443,10 +443,10 @@ class PickFilesViewModel @Inject constructor(
 
         val contactsMap = mutableMapOf<String, Contact>()
 
-        context.contentResolver.query(sessionUris, projection, null, null, null)?.use { cursor ->
+        context.contentResolver.query(sessionUri, projection, null, null, null)?.use { cursor ->
             val indices = cursor.contactProjectionIndicesOrNull()
             if (indices == null) {
-                SentryLog.e(TAG, "Projection invalide, colonnes manquantes.")
+                SentryLog.e(TAG, "Invalid projection, missing columns.")
                 return@use
             }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
@@ -24,6 +24,7 @@ import android.content.Context
 import android.database.Cursor
 import android.net.Uri
 import android.provider.ContactsContract
+import android.provider.ContactsContract.CommonDataKinds.Email
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,6 +34,7 @@ import androidx.core.net.toUri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.infomaniak.core.common.cancellable
 import com.infomaniak.core.common.mapSync
 import com.infomaniak.core.common.tryCompletingWhileTrue
 import com.infomaniak.core.common.utils.isEmailRfc5321Compliant
@@ -64,7 +66,6 @@ import com.infomaniak.swisstransfer.upload.UploadForegroundService
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
@@ -195,7 +196,8 @@ class PickFilesViewModel @Inject constructor(
             initialValue = FilesDetailsUiState.Success(emptyList()),
         )
 
-        @OptIn(FlowPreview::class) importedFilesDebounced = pickedFilesFlow.debounce(50).stateIn(
+        @OptIn(FlowPreview::class)
+        importedFilesDebounced = pickedFilesFlow.debounce(50).stateIn(
             scope = viewModelScope,
             started = SharingStarted.Lazily,
             initialValue = emptyList(),
@@ -254,7 +256,8 @@ class PickFilesViewModel @Inject constructor(
     }
 
     private fun pickedFilesIssues(
-        maxFilesSize: Long = FileUtils.MAX_FILES_SIZE, maxFilesCount: Int = FileUtils.MAX_FILE_COUNT
+        maxFilesSize: Long = FileUtils.MAX_FILES_SIZE,
+        maxFilesCount: Int = FileUtils.MAX_FILE_COUNT
     ): StateFlow<Set<Issue>> = UploadForegroundService.pickedFilesFlow.mapSync { pickedFiles ->
         if (pickedFiles.isEmpty()) {
             setOf(Issue.Files.NonePicked)
@@ -407,31 +410,22 @@ class PickFilesViewModel @Inject constructor(
         }
     }
 
-    private data class Contact(
-        val lookupKey: String,
-        val emails: List<String>,
-    )
-
-    fun processContactPickerResultUri(
-        sessionUri: Uri,
-    ) {
+    fun processContactPickerResultUri(sessionUri: Uri) {
         viewModelScope.launch {
-            try {
+            runCatching {
                 contactPickLaunch(sessionUri, appContext)
-            } catch (e: Exception) {
-                SentryLog.e(TAG, "Error while importing contacts from picker result", e)
-            }
+            }.cancellable()
+                .onFailure { exception ->
+                    SentryLog.e(TAG, "Error while importing contacts from picker result", exception)
+                }
         }
     }
 
-    private suspend fun contactPickLaunch(
-        sessionUri: Uri,
-        context: Context,
-    ) {
+    private suspend fun contactPickLaunch(sessionUri: Uri, context: Context) {
         val contacts = queryContacts(sessionUri, context)
-        val newEmails = contacts.values.asSequence().flatMap { it.emails.asSequence() }.toSet()
+        val newEmails = contacts.values.flatMapTo(mutableSetOf()) { it.emails.asSequence() }.toSet()
 
-        updateValidatedRecipientsEmails(newEmails)
+        validatedRecipientsEmails = validatedRecipientsEmails + newEmails
     }
 
     private suspend fun queryContacts(
@@ -454,8 +448,8 @@ class PickFilesViewModel @Inject constructor(
             }
 
             while (cursor.moveToNext()) {
-                val lookupKey = cursor.getString(indices.lookupKeyIdx)
-                val email = cursor.emailOrNull(indices.mimeTypeIdx, indices.data1Idx) ?: continue
+                val lookupKey = cursor.getString(indices.lookupKeyIndex)
+                val email = cursor.emailOrNull(indices.mimeTypeIndex, indices.data1Index) ?: continue
 
                 val current = contactsMap[lookupKey] ?: Contact(lookupKey = lookupKey, emails = emptyList())
                 contactsMap[lookupKey] = current.copy(emails = current.emails + email)
@@ -464,38 +458,39 @@ class PickFilesViewModel @Inject constructor(
         contactsMap
     }
 
-    private suspend fun updateValidatedRecipientsEmails(newEmails: Set<String>) = withContext(ioDispatcher) {
-        validatedRecipientsEmails = validatedRecipientsEmails + newEmails
-    }
-
-    private data class ContactProjectionIndices(
-        val lookupKeyIdx: Int,
-        val mimeTypeIdx: Int,
-        val data1Idx: Int,
-    )
-
     private fun Cursor.contactProjectionIndicesOrNull(): ContactProjectionIndices? {
-        val lookupKeyIdx = getColumnIndex(ContactsContract.Contacts.LOOKUP_KEY)
-        val mimeTypeIdx = getColumnIndex(ContactsContract.Data.MIMETYPE)
-        val data1Idx = getColumnIndex(ContactsContract.Data.DATA1)
+        val lookupKeyIndex = getColumnIndex(ContactsContract.Contacts.LOOKUP_KEY)
+        val mimeTypeIndex = getColumnIndex(ContactsContract.Data.MIMETYPE)
+        val data1Index = getColumnIndex(ContactsContract.Data.DATA1)
 
-        return if (lookupKeyIdx == -1 || mimeTypeIdx == -1 || data1Idx == -1) {
+        return if (lookupKeyIndex == -1 || mimeTypeIndex == -1 || data1Index == -1) {
             null
         } else {
             ContactProjectionIndices(
-                lookupKeyIdx = lookupKeyIdx,
-                mimeTypeIdx = mimeTypeIdx,
-                data1Idx = data1Idx,
+                lookupKeyIndex = lookupKeyIndex,
+                mimeTypeIndex = mimeTypeIndex,
+                data1Index = data1Index,
             )
         }
     }
 
     private fun Cursor.emailOrNull(mimeTypeIdx: Int, data1Idx: Int): String? {
         val mimeType = getString(mimeTypeIdx)
-        if (mimeType != ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE) return null
+        if (mimeType != Email.CONTENT_ITEM_TYPE) return null
 
         return getString(data1Idx)
     }
+
+    private data class ContactProjectionIndices(
+        val lookupKeyIndex: Int,
+        val mimeTypeIndex: Int,
+        val data1Index: Int,
+    )
+
+    private data class Contact(
+        val lookupKey: String,
+        val emails: List<String>,
+    )
 //endregion
 
     companion object {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
@@ -410,10 +410,10 @@ class PickFilesViewModel @Inject constructor(
         }
     }
 
-    fun processContactPickerResultUri(sessionUri: Uri) {
+    fun processContactPickerResultUri(pickedContactUri: Uri) {
         viewModelScope.launch {
             runCatching {
-                contactPickLaunch(sessionUri, appContext)
+                contactPickLaunch(pickedContactUri, appContext)
             }.cancellable()
                 .onFailure { exception ->
                     SentryLog.e(TAG, "Error while importing contacts from picker result", exception)
@@ -421,15 +421,15 @@ class PickFilesViewModel @Inject constructor(
         }
     }
 
-    private suspend fun contactPickLaunch(sessionUri: Uri, context: Context) {
-        val contacts = queryContacts(sessionUri, context)
         val newEmails = contacts.values.flatMapTo(mutableSetOf()) { it.emails.asSequence() }.toSet()
+    private suspend fun contactPickLaunch(pickedContactUri: Uri, context: Context) {
+        val contacts = queryContacts(pickedContactUri, context)
 
         validatedRecipientsEmails = validatedRecipientsEmails + newEmails
     }
 
     private suspend fun queryContacts(
-        sessionUri: Uri,
+        pickedContactUri: Uri,
         context: Context,
     ): Map<String, Contact> = withContext(ioDispatcher) {
         val projection = arrayOf(

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
@@ -414,10 +414,12 @@ class PickFilesViewModel @Inject constructor(
         sessionUri: Uri,
         context: Context,
     ) {
-        try {
-            viewModelScope.launch { contactPickLaunch(sessionUri, context) }
-        } catch (e: Exception) {
-            SentryLog.e(TAG, "Error while importing contacts from picker result", e)
+        viewModelScope.launch {
+            try {
+                contactPickLaunch(sessionUri, context)
+            } catch (e: Exception) {
+                SentryLog.e(TAG, "Error while importing contacts from picker result", e)
+            }
         }
     }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
@@ -23,7 +23,6 @@ package com.infomaniak.swisstransfer.ui.screen.newtransfer.pickfiles
 import android.content.Context
 import android.database.Cursor
 import android.net.Uri
-import android.provider.ContactsContract
 import android.provider.ContactsContract.CommonDataKinds.Email
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -83,6 +82,7 @@ import kotlinx.coroutines.withContext
 import splitties.coroutines.repeatWhileActive
 import splitties.experimental.ExperimentalSplittiesApi
 import javax.inject.Inject
+import kotlin.collections.mutableSetOf
 
 @HiltViewModel
 class PickFilesViewModel @Inject constructor(
@@ -440,23 +440,24 @@ class PickFilesViewModel @Inject constructor(
         context: Context,
     ): Map<String, Contact> = withContext(ioDispatcher) {
         val projection = arrayOf(
-            ContactsContract.Contacts.LOOKUP_KEY,
-            ContactsContract.Data.MIMETYPE,
-            ContactsContract.Data.DATA1,
+            Email.LOOKUP_KEY,
+            Email.ADDRESS,
         )
 
         val contactsMap = mutableMapOf<String, Contact>()
 
-        context.contentResolver.query(sessionUri, projection, null, null, null)?.use { cursor ->
-            val indices = cursor.contactProjectionIndicesOrNull()
-            if (indices == null) {
+        context.contentResolver.query(pickedContactUri, projection, null, null, null)?.use { cursor ->
+            val lookupKeyIndex = cursor.getColumnIndex(Email.LOOKUP_KEY)
+            val addressIndex = cursor.getColumnIndex(Email.ADDRESS)
+
+            if (lookupKeyIndex == -1 || addressIndex == -1) {
                 SentryLog.e(TAG, "Invalid projection, missing columns.")
                 return@use
             }
 
             while (cursor.moveToNext()) {
-                val lookupKey = cursor.getString(indices.lookupKeyIndex)
-                val email = cursor.emailOrNull(indices.mimeTypeIndex, indices.data1Index) ?: continue
+                val lookupKey = cursor.getString(lookupKeyIndex)?.takeIf { it.isNotBlank() } ?: continue
+                val email = cursor.getString(addressIndex)?.takeIf { it.isNotBlank() } ?: continue
 
                 val current = contactsMap[lookupKey] ?: Contact(lookupKey = lookupKey, emails = emptyList())
                 contactsMap[lookupKey] = current.copy(emails = current.emails + email)
@@ -464,35 +465,6 @@ class PickFilesViewModel @Inject constructor(
         }
         contactsMap
     }
-
-    private fun Cursor.contactProjectionIndicesOrNull(): ContactProjectionIndices? {
-        val lookupKeyIndex = getColumnIndex(ContactsContract.Contacts.LOOKUP_KEY)
-        val mimeTypeIndex = getColumnIndex(ContactsContract.Data.MIMETYPE)
-        val data1Index = getColumnIndex(ContactsContract.Data.DATA1)
-
-        return if (lookupKeyIndex == -1 || mimeTypeIndex == -1 || data1Index == -1) {
-            null
-        } else {
-            ContactProjectionIndices(
-                lookupKeyIndex = lookupKeyIndex,
-                mimeTypeIndex = mimeTypeIndex,
-                data1Index = data1Index,
-            )
-        }
-    }
-
-    private fun Cursor.emailOrNull(mimeTypeIdx: Int, data1Idx: Int): String? {
-        val mimeType = getString(mimeTypeIdx)
-        if (mimeType != Email.CONTENT_ITEM_TYPE) return null
-
-        return getString(data1Idx)
-    }
-
-    private data class ContactProjectionIndices(
-        val lookupKeyIndex: Int,
-        val mimeTypeIndex: Int,
-        val data1Index: Int,
-    )
 
     private data class Contact(
         val lookupKey: String,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
@@ -464,7 +464,7 @@ class PickFilesViewModel @Inject constructor(
         contactsMap
     }
 
-    private suspend fun updateValidatedRecipientsEmails(newEmails: Set<String>) = withContext(Dispatchers.Main) {
+    private suspend fun updateValidatedRecipientsEmails(newEmails: Set<String>) = withContext(ioDispatcher) {
         validatedRecipientsEmails = validatedRecipientsEmails + newEmails
     }
 

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
@@ -421,11 +421,18 @@ class PickFilesViewModel @Inject constructor(
         }
     }
 
-        val newEmails = contacts.values.flatMapTo(mutableSetOf()) { it.emails.asSequence() }.toSet()
     private suspend fun contactPickLaunch(pickedContactUri: Uri, context: Context) {
         val contacts = queryContacts(pickedContactUri, context)
+        val newEmails = normalizeAndValidateEmails(contacts.values.flatMapTo(mutableSetOf()) { it.emails }.toSet())
 
         validatedRecipientsEmails = validatedRecipientsEmails + newEmails
+    }
+
+    private fun normalizeAndValidateEmails(emails: Iterable<String>): Set<String> {
+        return emails.mapNotNullTo(mutableSetOf()) { email ->
+            email.trim()
+                .takeIf { it.isNotEmpty() && it.isEmailRfc5321Compliant() }
+        }
     }
 
     private suspend fun queryContacts(

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
@@ -62,6 +62,7 @@ import com.infomaniak.swisstransfer.ui.utils.GetSetCallbacks
 import com.infomaniak.swisstransfer.upload.NewTransferParams
 import com.infomaniak.swisstransfer.upload.UploadForegroundService
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
@@ -84,6 +85,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class PickFilesViewModel @Inject constructor(
+    @ApplicationContext private val appContext: Context,
     private val accountUtils: AccountUtils,
     private val appSettingsManager: AppSettingsManager,
     private val newTransferOpenManager: NewTransferOpenManager,
@@ -412,11 +414,10 @@ class PickFilesViewModel @Inject constructor(
 
     fun processContactPickerResultUri(
         sessionUri: Uri,
-        context: Context,
     ) {
         viewModelScope.launch {
             try {
-                contactPickLaunch(sessionUri, context)
+                contactPickLaunch(sessionUri, appContext)
             } catch (e: Exception) {
                 SentryLog.e(TAG, "Error while importing contacts from picker result", e)
             }

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak SwissTransfer - Android
- * Copyright (C) 2024-2025 Infomaniak Network SA
+ * Copyright (C) 2024-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,7 +21,6 @@
 package com.infomaniak.swisstransfer.ui.screen.newtransfer.pickfiles
 
 import android.content.Context
-import android.database.Cursor
 import android.net.Uri
 import android.provider.ContactsContract.CommonDataKinds.Email
 import androidx.compose.runtime.derivedStateOf
@@ -82,7 +81,6 @@ import kotlinx.coroutines.withContext
 import splitties.coroutines.repeatWhileActive
 import splitties.experimental.ExperimentalSplittiesApi
 import javax.inject.Inject
-import kotlin.collections.mutableSetOf
 
 @HiltViewModel
 class PickFilesViewModel @Inject constructor(
@@ -414,36 +412,28 @@ class PickFilesViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching {
                 contactPickLaunch(pickedContactUri, appContext)
-            }.cancellable()
-                .onFailure { exception ->
-                    SentryLog.e(TAG, "Error while importing contacts from picker result", exception)
-                }
+            }.cancellable().onFailure { exception ->
+                SentryLog.e(TAG, "Error while importing contacts from picker result", exception)
+            }
         }
     }
 
     private suspend fun contactPickLaunch(pickedContactUri: Uri, context: Context) {
         val contacts = queryContacts(pickedContactUri, context)
-        val newEmails = normalizeAndValidateEmails(contacts.values.flatMapTo(mutableSetOf()) { it.emails }.toSet())
+        val newEmails = contacts.values.flatMapTo(mutableSetOf()) { contact ->
+            contact.emails.mapNotNull { email ->
+                email.trim().takeIf { it.isNotEmpty() && it.isEmailRfc5321Compliant() }
+            }
+        }
 
         validatedRecipientsEmails = validatedRecipientsEmails + newEmails
-    }
-
-    private fun normalizeAndValidateEmails(emails: Iterable<String>): Set<String> {
-        return emails.mapNotNullTo(mutableSetOf()) { email ->
-            email.trim()
-                .takeIf { it.isNotEmpty() && it.isEmailRfc5321Compliant() }
-        }
     }
 
     private suspend fun queryContacts(
         pickedContactUri: Uri,
         context: Context,
     ): Map<String, Contact> = withContext(ioDispatcher) {
-        val projection = arrayOf(
-            Email.LOOKUP_KEY,
-            Email.ADDRESS,
-        )
-
+        val projection = arrayOf(Email.LOOKUP_KEY, Email.ADDRESS)
         val contactsMap = mutableMapOf<String, Contact>()
 
         context.contentResolver.query(pickedContactUri, projection, null, null, null)?.use { cursor ->

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/PickFilesViewModel.kt
@@ -411,14 +411,14 @@ class PickFilesViewModel @Inject constructor(
     fun processContactPickerResultUri(pickedContactUri: Uri) {
         viewModelScope.launch {
             runCatching {
-                contactPickLaunch(pickedContactUri, appContext)
+                addContactEmail(pickedContactUri, appContext)
             }.cancellable().onFailure { exception ->
                 SentryLog.e(TAG, "Error while importing contacts from picker result", exception)
             }
         }
     }
 
-    private suspend fun contactPickLaunch(pickedContactUri: Uri, context: Context) {
+    private suspend fun addContactEmail(pickedContactUri: Uri, context: Context) {
         val contacts = queryContacts(pickedContactUri, context)
         val newEmails = contacts.values.flatMapTo(mutableSetOf()) { contact ->
             contact.emails.mapNotNull { email ->

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/components/EmailAddressTextField.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/components/EmailAddressTextField.kt
@@ -83,16 +83,18 @@ import com.infomaniak.swisstransfer.ui.previewparameter.EmailsPreviewParameter
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.GetSetCallbacks
 
+
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun EmailAddressTextField(
-    modifier: Modifier = Modifier,
     label: String,
     initialValue: String,
     validatedRecipientsEmails: GetSetCallbacks<Set<String>>,
     onValueChange: (TextFieldValue) -> Unit,
+    modifier: Modifier = Modifier,
     isError: Boolean = false,
     supportingText: (@Composable () -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
 ) {
 
     val state = remember(validatedRecipientsEmails) {
@@ -154,10 +156,12 @@ fun EmailAddressTextField(
                 isError = isError,
                 supportingText = supportingText,
                 textFieldColors = SwissTransferTextFieldDefaults.colors(),
+                trailingIcon = trailingIcon,
             )
         }
     )
 }
+
 
 /**
  * Copied from OutlineTextField so the BasicTextField can have the same spacing as OutlineTextField with a label
@@ -289,6 +293,7 @@ private fun EmailAddressDecorationBox(
     isError: Boolean,
     supportingText: @Composable (() -> Unit)?,
     textFieldColors: TextFieldColors,
+    trailingIcon: @Composable (() -> Unit)? = null
 ) {
     OutlinedTextFieldDefaults.DecorationBox(
         value = text,
@@ -313,6 +318,7 @@ private fun EmailAddressDecorationBox(
         supportingText = supportingText,
         label = { Text(label) },
         colors = textFieldColors,
+        trailingIcon = trailingIcon,
     ) {
         OutlinedTextFieldDefaults.Container(
             enabled = true,

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/components/EmailAddressTextField.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/newtransfer/pickfiles/components/EmailAddressTextField.kt
@@ -83,7 +83,6 @@ import com.infomaniak.swisstransfer.ui.previewparameter.EmailsPreviewParameter
 import com.infomaniak.swisstransfer.ui.theme.SwissTransferTheme
 import com.infomaniak.swisstransfer.ui.utils.GetSetCallbacks
 
-
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun EmailAddressTextField(
@@ -161,7 +160,6 @@ fun EmailAddressTextField(
         }
     )
 }
-
 
 /**
  * Copied from OutlineTextField so the BasicTextField can have the same spacing as OutlineTextField with a label

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -39,6 +39,7 @@
     <string name="contentDescriptionButtonHidePassword">Skjul adgangskode</string>
     <string name="contentDescriptionButtonRemove">Fjern fil</string>
     <string name="contentDescriptionButtonRemoveRecipient">Fjern %s</string>
+    <string name="contentDescriptionButtonSelectContact">Åbn kontaktlisten</string>
     <string name="contentDescriptionButtonShowPassword">Vis adgangskode</string>
     <string name="contentDescriptionCreateNewTransferButton">Ny overføring</string>
     <string name="deeplinkPasswordDescription">Indtast den adgangskode, du har modtaget, for at downloade disse filer.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -50,6 +50,7 @@
     <string name="deleteThisTransferDescription">Denne overføring og de filer, den indeholder, vil blive slettet.</string>
     <string name="deleteThisTransferTitle">Slet denne overføring?</string>
     <string name="downloadedTransferLabel">Downloadet overføring: %d/%d</string>
+    <string name="errorContactPicker">Hentning af kontakter mislykkedes.</string>
     <string name="errorIncorrectPassword">Forkert adgangskode</string>
     <string name="errorTransferPasswordLength">Adgangskoden skal være mellem 6 og 25 tegn</string>
     <string name="expired">Udløbet</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -40,6 +40,7 @@
     <string name="contentDescriptionButtonHidePassword">Skjul adgangskode</string>
     <string name="contentDescriptionButtonRemove">Fjern fil</string>
     <string name="contentDescriptionButtonRemoveRecipient">Fjern %s</string>
+    <string name="contentDescriptionButtonSelectContact">Åbn kontaktlisten</string>
     <string name="contentDescriptionButtonShowPassword">Vis adgangskode</string>
     <string name="contentDescriptionCreateNewTransferButton">Ny overføring</string>
     <string name="contentDescriptionViewTransferDetails">Se overførselsdetaljer</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -39,6 +39,7 @@
     <string name="contentDescriptionButtonHidePassword">Passwort verbergen</string>
     <string name="contentDescriptionButtonRemove">Datei entfernen</string>
     <string name="contentDescriptionButtonRemoveRecipient">%s entfernen</string>
+    <string name="contentDescriptionButtonSelectContact">Kontaktliste öffnen</string>
     <string name="contentDescriptionButtonShowPassword">Passwort anzeigen</string>
     <string name="contentDescriptionCreateNewTransferButton">Neuer Transfer</string>
     <string name="deeplinkPasswordDescription">Gib das Passwort ein, das du erhalten hast, um diese Dateien herunterzuladen.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -50,6 +50,7 @@
     <string name="deleteThisTransferDescription">Diese Übertragung und die darin enthaltenen Dateien werden gelöscht.</string>
     <string name="deleteThisTransferTitle">Diese Übertragung löschen?</string>
     <string name="downloadedTransferLabel">Heruntergeladene Übertragung: %d/%d</string>
+    <string name="errorContactPicker">Das Abrufen der Kontakte ist fehlgeschlagen.</string>
     <string name="errorIncorrectPassword">Falsches Kennwort</string>
     <string name="errorTransferPasswordLength">Das Passwort muss zwischen 6 und 25 Zeichen lang sein</string>
     <string name="expired">Abgelaufen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -40,6 +40,7 @@
     <string name="contentDescriptionButtonHidePassword">Passwort verbergen</string>
     <string name="contentDescriptionButtonRemove">Datei entfernen</string>
     <string name="contentDescriptionButtonRemoveRecipient">%s entfernen</string>
+    <string name="contentDescriptionButtonSelectContact">Kontaktliste öffnen</string>
     <string name="contentDescriptionButtonShowPassword">Passwort anzeigen</string>
     <string name="contentDescriptionCreateNewTransferButton">Neuer Transfer</string>
     <string name="contentDescriptionViewTransferDetails">Übertragungsdetails anzeigen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -39,6 +39,7 @@
     <string name="contentDescriptionButtonHidePassword">Απόκρυψη κωδικού πρόσβασης</string>
     <string name="contentDescriptionButtonRemove">Αφαίρεση αρχείου</string>
     <string name="contentDescriptionButtonRemoveRecipient">Αφαίρεση %s</string>
+    <string name="contentDescriptionButtonSelectContact">Άνοιγμα λίστας επαφών</string>
     <string name="contentDescriptionButtonShowPassword">Εμφάνιση κωδικού πρόσβασης</string>
     <string name="contentDescriptionCreateNewTransferButton">Νέα μεταφορά</string>
     <string name="deeplinkPasswordDescription">Εισάγαλε τον κωδικό πρόσβασης που σου δόθηκε για να κατεβάσεις αυτά τα αρχεία.</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -50,6 +50,7 @@
     <string name="deleteThisTransferDescription">Αυτή η μεταφορά και τα αρχεία που περιέχει θα διαγραφούν.</string>
     <string name="deleteThisTransferTitle">Διαγραφή αυτής της μεταφοράς;</string>
     <string name="downloadedTransferLabel">Ληφθείσα μεταφορά: %d/%d</string>
+    <string name="errorContactPicker">Η ανάκτηση επαφών απέτυχε.</string>
     <string name="errorIncorrectPassword">Λανθασμένος κωδικός πρόσβασης</string>
     <string name="errorTransferPasswordLength">Ο κωδικός πρόσβασης πρέπει να είναι μεταξύ 6 και 25 χαρακτήρων</string>
     <string name="expired">Ληγμένο</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -40,6 +40,7 @@
     <string name="contentDescriptionButtonHidePassword">Απόκρυψη κωδικού πρόσβασης</string>
     <string name="contentDescriptionButtonRemove">Αφαίρεση αρχείου</string>
     <string name="contentDescriptionButtonRemoveRecipient">Αφαίρεση %s</string>
+    <string name="contentDescriptionButtonSelectContact">Άνοιγμα λίστας επαφών</string>
     <string name="contentDescriptionButtonShowPassword">Εμφάνιση κωδικού πρόσβασης</string>
     <string name="contentDescriptionCreateNewTransferButton">Νέα μεταφορά</string>
     <string name="contentDescriptionViewTransferDetails">Προβολή λεπτομερειών μεταφοράς</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -39,6 +39,7 @@
     <string name="contentDescriptionButtonHidePassword">Ocultar contraseña</string>
     <string name="contentDescriptionButtonRemove">Eliminar archivo</string>
     <string name="contentDescriptionButtonRemoveRecipient">Suprimir %s</string>
+    <string name="contentDescriptionButtonSelectContact">Abrir la lista de contactos</string>
     <string name="contentDescriptionButtonShowPassword">Mostrar contraseña</string>
     <string name="contentDescriptionCreateNewTransferButton">Nueva transferencia</string>
     <string name="deeplinkPasswordDescription">Introduzca la contraseña que se le ha dado para descargar estos archivos.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -40,6 +40,7 @@
     <string name="contentDescriptionButtonHidePassword">Ocultar contraseña</string>
     <string name="contentDescriptionButtonRemove">Eliminar archivo</string>
     <string name="contentDescriptionButtonRemoveRecipient">Suprimir %s</string>
+    <string name="contentDescriptionButtonSelectContact">Abrir la lista de contactos</string>
     <string name="contentDescriptionButtonShowPassword">Mostrar contraseña</string>
     <string name="contentDescriptionCreateNewTransferButton">Nueva transferencia</string>
     <string name="contentDescriptionViewTransferDetails">Ver detalles de la transferencia</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -50,6 +50,7 @@
     <string name="deleteThisTransferDescription">Esta transferencia y los archivos que contiene serán eliminados.</string>
     <string name="deleteThisTransferTitle">¿Suprimir esta transferencia?</string>
     <string name="downloadedTransferLabel">Transferencia descargada: %d/%d</string>
+    <string name="errorContactPicker">Error al recuperar los contactos.</string>
     <string name="errorIncorrectPassword">Contraseña incorrecta</string>
     <string name="errorTransferPasswordLength">La contraseña debe tener entre 6 y 25 caracteres</string>
     <string name="expired">Expirado</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -39,6 +39,7 @@
     <string name="contentDescriptionButtonHidePassword">Piilota salasana</string>
     <string name="contentDescriptionButtonRemove">Poista tiedosto</string>
     <string name="contentDescriptionButtonRemoveRecipient">Poista %s</string>
+    <string name="contentDescriptionButtonSelectContact">Avaa yhteysluettelo</string>
     <string name="contentDescriptionButtonShowPassword">Näytä salasana</string>
     <string name="contentDescriptionCreateNewTransferButton">Uusi siirto</string>
     <string name="deeplinkPasswordDescription">Syötä saamasi salasana ladataksesi nämä tiedostot.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -40,6 +40,7 @@
     <string name="contentDescriptionButtonHidePassword">Piilota salasana</string>
     <string name="contentDescriptionButtonRemove">Poista tiedosto</string>
     <string name="contentDescriptionButtonRemoveRecipient">Poista %s</string>
+    <string name="contentDescriptionButtonSelectContact">Avaa yhteysluettelo</string>
     <string name="contentDescriptionButtonShowPassword">Näytä salasana</string>
     <string name="contentDescriptionCreateNewTransferButton">Uusi siirto</string>
     <string name="contentDescriptionViewTransferDetails">Katso siirron tiedot</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -50,6 +50,7 @@
     <string name="deleteThisTransferDescription">Tämä siirto ja sen sisältämät tiedostot poistetaan.</string>
     <string name="deleteThisTransferTitle">Poistetaanko tämä siirto?</string>
     <string name="downloadedTransferLabel">Ladattu siirto: %d/%d</string>
+    <string name="errorContactPicker">Yhteystietojen nouto epäonnistui.</string>
     <string name="errorIncorrectPassword">Virheellinen salasana</string>
     <string name="errorTransferPasswordLength">Salasanan täytyy olla 6–25 merkkiä pitkä</string>
     <string name="expired">Vanhentunut</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -39,6 +39,7 @@
     <string name="contentDescriptionButtonHidePassword">Cacher le mot de passe</string>
     <string name="contentDescriptionButtonRemove">Supprimer le fichier</string>
     <string name="contentDescriptionButtonRemoveRecipient">Supprimer %s</string>
+    <string name="contentDescriptionButtonSelectContact">Ouvrir la liste des contacts</string>
     <string name="contentDescriptionButtonShowPassword">Afficher le mot de passe</string>
     <string name="contentDescriptionCreateNewTransferButton">Nouveau transfert</string>
     <string name="deeplinkPasswordDescription">Saisis le mot de passe qui t’a été fourni pour télécharger ces fichiers.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -50,6 +50,7 @@
     <string name="deleteThisTransferDescription">Ce transfert et les fichiers qu’il contient seront supprimés.</string>
     <string name="deleteThisTransferTitle">Supprimer ce transfert ?</string>
     <string name="downloadedTransferLabel">Transfert téléchargé : %d/%d</string>
+    <string name="errorContactPicker">La récupération des contacts a échoué.</string>
     <string name="errorIncorrectPassword">Mot de passe incorrect</string>
     <string name="errorTransferPasswordLength">Le mot de passe doit comporter entre 6 et 25 caractères</string>
     <string name="expired">Expiré</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -40,6 +40,7 @@
     <string name="contentDescriptionButtonHidePassword">Cacher le mot de passe</string>
     <string name="contentDescriptionButtonRemove">Supprimer le fichier</string>
     <string name="contentDescriptionButtonRemoveRecipient">Supprimer %s</string>
+    <string name="contentDescriptionButtonSelectContact">Ouvrir la liste des contacts</string>
     <string name="contentDescriptionButtonShowPassword">Afficher le mot de passe</string>
     <string name="contentDescriptionCreateNewTransferButton">Nouveau transfert</string>
     <string name="contentDescriptionViewTransferDetails">Voir les détails du transfert</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -39,6 +39,7 @@
     <string name="contentDescriptionButtonHidePassword">Nascondere la password</string>
     <string name="contentDescriptionButtonRemove">Rimuovi il file</string>
     <string name="contentDescriptionButtonRemoveRecipient">Rimuove %s</string>
+    <string name="contentDescriptionButtonSelectContact">Apri l\'elenco contatti</string>
     <string name="contentDescriptionButtonShowPassword">Mostra password</string>
     <string name="contentDescriptionCreateNewTransferButton">Nuovo trasferimento</string>
     <string name="deeplinkPasswordDescription">Inserite la password che vi è stata fornita per scaricare questi file.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -39,7 +39,7 @@
     <string name="contentDescriptionButtonHidePassword">Nascondere la password</string>
     <string name="contentDescriptionButtonRemove">Rimuovi il file</string>
     <string name="contentDescriptionButtonRemoveRecipient">Rimuove %s</string>
-    <string name="contentDescriptionButtonSelectContact">Apri l\'elenco contatti</string>
+    <string name="contentDescriptionButtonSelectContact">Apri l’elenco contatti</string>
     <string name="contentDescriptionButtonShowPassword">Mostra password</string>
     <string name="contentDescriptionCreateNewTransferButton">Nuovo trasferimento</string>
     <string name="deeplinkPasswordDescription">Inserite la password che vi è stata fornita per scaricare questi file.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -40,7 +40,7 @@
     <string name="contentDescriptionButtonHidePassword">Nascondere la password</string>
     <string name="contentDescriptionButtonRemove">Rimuovi il file</string>
     <string name="contentDescriptionButtonRemoveRecipient">Rimuove %s</string>
-    <string name="contentDescriptionButtonSelectContact">Apri l\'elenco contatti</string>
+    <string name="contentDescriptionButtonSelectContact">Apri l’elenco contatti</string>
     <string name="contentDescriptionButtonShowPassword">Mostra password</string>
     <string name="contentDescriptionCreateNewTransferButton">Nuovo trasferimento</string>
     <string name="contentDescriptionViewTransferDetails">Vedi dettagli del trasferimento</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -40,6 +40,7 @@
     <string name="contentDescriptionButtonHidePassword">Nascondere la password</string>
     <string name="contentDescriptionButtonRemove">Rimuovi il file</string>
     <string name="contentDescriptionButtonRemoveRecipient">Rimuove %s</string>
+    <string name="contentDescriptionButtonSelectContact">Apri l\'elenco contatti</string>
     <string name="contentDescriptionButtonShowPassword">Mostra password</string>
     <string name="contentDescriptionCreateNewTransferButton">Nuovo trasferimento</string>
     <string name="contentDescriptionViewTransferDetails">Vedi dettagli del trasferimento</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -50,6 +50,7 @@
     <string name="deleteThisTransferDescription">Questo trasferimento e i file in esso contenuti verranno eliminati.</string>
     <string name="deleteThisTransferTitle">Cancellare questo trasferimento?</string>
     <string name="downloadedTransferLabel">Trasferimento scaricato: %d/%d</string>
+    <string name="errorContactPicker">Recupero contatti non riuscito.</string>
     <string name="errorIncorrectPassword">Password errata</string>
     <string name="errorTransferPasswordLength">La password deve essere compresa tra 6 e 24 caratteri</string>
     <string name="expired">Scaduto</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -39,6 +39,7 @@
     <string name="contentDescriptionButtonHidePassword">Skjul passord</string>
     <string name="contentDescriptionButtonRemove">Fjern fil</string>
     <string name="contentDescriptionButtonRemoveRecipient">Fjern %s</string>
+    <string name="contentDescriptionButtonSelectContact">Åpne kontaktlisten</string>
     <string name="contentDescriptionButtonShowPassword">Vis passord</string>
     <string name="contentDescriptionCreateNewTransferButton">Ny overføring</string>
     <string name="deeplinkPasswordDescription">Skriv inn passordet du har fått for å laste ned disse filene.</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -50,6 +50,7 @@
     <string name="deleteThisTransferDescription">Denne overføringen og filene den inneholder vil bli slettet.</string>
     <string name="deleteThisTransferTitle">Slette denne overføringen?</string>
     <string name="downloadedTransferLabel">Lastet ned overføring: %d/%d</string>
+    <string name="errorContactPicker">Henting av kontakter mislyktes.</string>
     <string name="errorIncorrectPassword">Feil passord</string>
     <string name="errorTransferPasswordLength">Passordet må være mellom 6 og 25 tegn</string>
     <string name="expired">Utløpt</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -40,6 +40,7 @@
     <string name="contentDescriptionButtonHidePassword">Skjul passord</string>
     <string name="contentDescriptionButtonRemove">Fjern fil</string>
     <string name="contentDescriptionButtonRemoveRecipient">Fjern %s</string>
+    <string name="contentDescriptionButtonSelectContact">Åpne kontaktlisten</string>
     <string name="contentDescriptionButtonShowPassword">Vis passord</string>
     <string name="contentDescriptionCreateNewTransferButton">Ny overføring</string>
     <string name="contentDescriptionViewTransferDetails">Se overføringsdetaljer</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -39,6 +39,7 @@
     <string name="contentDescriptionButtonHidePassword">Wachtwoord verbergen</string>
     <string name="contentDescriptionButtonRemove">Bestand verwijderen</string>
     <string name="contentDescriptionButtonRemoveRecipient">%s verwijderen</string>
+    <string name="contentDescriptionButtonSelectContact">Contactenlijst openen</string>
     <string name="contentDescriptionButtonShowPassword">Wachtwoord weergeven</string>
     <string name="contentDescriptionCreateNewTransferButton">Nieuwe overdracht</string>
     <string name="deeplinkPasswordDescription">Voer het wachtwoord in dat je hebt ontvangen om deze bestanden te downloaden.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -50,6 +50,7 @@
     <string name="deleteThisTransferDescription">Deze overdracht en de bestanden die het bevat, worden verwijderd.</string>
     <string name="deleteThisTransferTitle">Deze overdracht verwijderen?</string>
     <string name="downloadedTransferLabel">Gedownloade overdracht: %d/%d</string>
+    <string name="errorContactPicker">Ophalen van contacten mislukt.</string>
     <string name="errorIncorrectPassword">Onjuist wachtwoord</string>
     <string name="errorTransferPasswordLength">Het wachtwoord moet tussen de 6 en 25 tekens bevatten</string>
     <string name="expired">Verlopen</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -40,6 +40,7 @@
     <string name="contentDescriptionButtonHidePassword">Wachtwoord verbergen</string>
     <string name="contentDescriptionButtonRemove">Bestand verwijderen</string>
     <string name="contentDescriptionButtonRemoveRecipient">%s verwijderen</string>
+    <string name="contentDescriptionButtonSelectContact">Contactenlijst openen</string>
     <string name="contentDescriptionButtonShowPassword">Wachtwoord weergeven</string>
     <string name="contentDescriptionCreateNewTransferButton">Nieuwe overdracht</string>
     <string name="contentDescriptionViewTransferDetails">Overdrachtsdetails bekijken</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -39,6 +39,7 @@
     <string name="contentDescriptionButtonHidePassword">Ukryj hasło</string>
     <string name="contentDescriptionButtonRemove">Usuń plik</string>
     <string name="contentDescriptionButtonRemoveRecipient">Usuń %s</string>
+    <string name="contentDescriptionButtonSelectContact">Otwórz listę kontaktów</string>
     <string name="contentDescriptionButtonShowPassword">Pokaż hasło</string>
     <string name="contentDescriptionCreateNewTransferButton">Nowy transfer</string>
     <string name="deeplinkPasswordDescription">Wprowadź hasło, które otrzymałeś, aby pobrać te pliki.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -40,6 +40,7 @@
     <string name="contentDescriptionButtonHidePassword">Ukryj hasło</string>
     <string name="contentDescriptionButtonRemove">Usuń plik</string>
     <string name="contentDescriptionButtonRemoveRecipient">Usuń %s</string>
+    <string name="contentDescriptionButtonSelectContact">Otwórz listę kontaktów</string>
     <string name="contentDescriptionButtonShowPassword">Pokaż hasło</string>
     <string name="contentDescriptionCreateNewTransferButton">Nowy transfer</string>
     <string name="contentDescriptionViewTransferDetails">Zobacz szczegóły transferu</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -50,6 +50,7 @@
     <string name="deleteThisTransferDescription">Ten transfer i zawarte w nim pliki zostaną usunięte.</string>
     <string name="deleteThisTransferTitle">Usunąć ten transfer?</string>
     <string name="downloadedTransferLabel">Pobrany transfer: %d/%d</string>
+    <string name="errorContactPicker">Pobieranie kontaktów nie powiodło się.</string>
     <string name="errorIncorrectPassword">Nieprawidłowe hasło</string>
     <string name="errorTransferPasswordLength">Hasło musi mieć od 6 do 25 znaków</string>
     <string name="expired">Wygasłe</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -39,6 +39,7 @@
     <string name="contentDescriptionButtonHidePassword">Ocultar palavra-passe</string>
     <string name="contentDescriptionButtonRemove">Remover ficheiro</string>
     <string name="contentDescriptionButtonRemoveRecipient">Remover %s</string>
+    <string name="contentDescriptionButtonSelectContact">Abrir a lista de contactos</string>
     <string name="contentDescriptionButtonShowPassword">Mostrar palavra-passe</string>
     <string name="contentDescriptionCreateNewTransferButton">Nova transferência</string>
     <string name="deeplinkPasswordDescription">Introduz a palavra-passe que te foi fornecida para descarregar estes ficheiros.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -50,6 +50,7 @@
     <string name="deleteThisTransferDescription">Esta transferência e os ficheiros que contém serão eliminados.</string>
     <string name="deleteThisTransferTitle">Eliminar esta transferência?</string>
     <string name="downloadedTransferLabel">Transferência descarregada: %d/%d</string>
+    <string name="errorContactPicker">A recuperação de contactos falhou.</string>
     <string name="errorIncorrectPassword">Palavra-passe incorreta</string>
     <string name="errorTransferPasswordLength">A palavra-passe deve ter entre 6 e 25 caracteres</string>
     <string name="expired">Expirado</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -40,6 +40,7 @@
     <string name="contentDescriptionButtonHidePassword">Ocultar palavra-passe</string>
     <string name="contentDescriptionButtonRemove">Remover ficheiro</string>
     <string name="contentDescriptionButtonRemoveRecipient">Remover %s</string>
+    <string name="contentDescriptionButtonSelectContact">Abrir a lista de contactos</string>
     <string name="contentDescriptionButtonShowPassword">Mostrar palavra-passe</string>
     <string name="contentDescriptionCreateNewTransferButton">Nova transferência</string>
     <string name="contentDescriptionViewTransferDetails">Ver detalhes da transferência</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -39,6 +39,7 @@
     <string name="contentDescriptionButtonHidePassword">Dölj lösenord</string>
     <string name="contentDescriptionButtonRemove">Ta bort fil</string>
     <string name="contentDescriptionButtonRemoveRecipient">Ta bort %s</string>
+    <string name="contentDescriptionButtonSelectContact">Öppna kontaktlistan</string>
     <string name="contentDescriptionButtonShowPassword">Visa lösenord</string>
     <string name="contentDescriptionCreateNewTransferButton">Ny överföring</string>
     <string name="deeplinkPasswordDescription">Ange lösenordet du har fått för att ladda ner dessa filer.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -50,6 +50,7 @@
     <string name="deleteThisTransferDescription">Denna överföring och filerna den innehåller kommer att tas bort.</string>
     <string name="deleteThisTransferTitle">Ta bort denna överföring?</string>
     <string name="downloadedTransferLabel">Nedladdad överföring: %d/%d</string>
+    <string name="errorContactPicker">Hämtning av kontakter misslyckades.</string>
     <string name="errorIncorrectPassword">Felaktigt lösenord</string>
     <string name="errorTransferPasswordLength">Lösenordet måste vara mellan 6 och 25 tecken</string>
     <string name="expired">Utgången</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -40,6 +40,7 @@
     <string name="contentDescriptionButtonHidePassword">Dölj lösenord</string>
     <string name="contentDescriptionButtonRemove">Ta bort fil</string>
     <string name="contentDescriptionButtonRemoveRecipient">Ta bort %s</string>
+    <string name="contentDescriptionButtonSelectContact">Öppna kontaktlistan</string>
     <string name="contentDescriptionButtonShowPassword">Visa lösenord</string>
     <string name="contentDescriptionCreateNewTransferButton">Ny överföring</string>
     <string name="contentDescriptionViewTransferDetails">Visa överföringsdetaljer</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,7 +20,6 @@
     <string name="matomo" translatable="false">Matomo</string>
     <string name="sentry" translatable="false">Sentry</string>
     <string name="notifications_upload_channel_id" translatable="false">upload_channel_id</string>
-
     <string name="advancedSettingsTitle">Advanced settings</string>
     <string name="awaitingNetwork">Waiting for network</string>
     <string name="buttonCancelTransfer">Cancel the transfer</string>
@@ -44,6 +43,7 @@
     <string name="contentDescriptionButtonHidePassword">Hide password</string>
     <string name="contentDescriptionButtonRemove">Remove file</string>
     <string name="contentDescriptionButtonRemoveRecipient">Remove %s</string>
+    <string name="contentDescriptionButtonSelectContact">Open the contacts list</string>
     <string name="contentDescriptionButtonShowPassword">Show password</string>
     <string name="contentDescriptionCreateNewTransferButton">New transfer</string>
     <string name="deeplinkPasswordDescription">Enter the password you have been given to download these files.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="deleteThisTransferDescription">This transfer and the files it contains will be deleted.</string>
     <string name="deleteThisTransferTitle">Delete this transfer?</string>
     <string name="downloadedTransferLabel">Downloaded transfer: %d/%d</string>
+    <string name="errorContactPicker">Contact retrieval failed.</string>
     <string name="errorIncorrectPassword">Incorrect password</string>
     <string name="errorTransferPasswordLength">The password must be between 6 and 25 characters</string>
     <string name="expired">Expired</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="matomo" translatable="false">Matomo</string>
     <string name="sentry" translatable="false">Sentry</string>
     <string name="notifications_upload_channel_id" translatable="false">upload_channel_id</string>
+
     <string name="advancedSettingsTitle">Advanced settings</string>
     <string name="awaitingNetwork">Waiting for network</string>
     <string name="buttonCancelTransfer">Cancel the transfer</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="contentDescriptionButtonHidePassword">Hide password</string>
     <string name="contentDescriptionButtonRemove">Remove file</string>
     <string name="contentDescriptionButtonRemoveRecipient">Remove %s</string>
+    <string name="contentDescriptionButtonSelectContact">Open the contacts list</string>
     <string name="contentDescriptionButtonShowPassword">Show password</string>
     <string name="contentDescriptionCreateNewTransferButton">New transfer</string>
     <string name="contentDescriptionViewTransferDetails">View transfer details</string>


### PR DESCRIPTION
Add a button in the input field for sending via email to open the native contact selection.

Note: New method available for Android 17; check it out when it's released.