### PR TITLE
fix: Fix selected settings item in tablet mode

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/MyAccountScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/MyAccountScreen.kt
@@ -323,8 +323,11 @@ sealed class MyAccountSettingAction(val matomoValue: MatomoName?) {
 
     data class SwitchAccount(val userId: Int) : MyAccountSettingAction(null) // Matomo sent by hand in the code
 
-    sealed class Navigation(val destination: SettingsOptionScreens) : MyAccountSettingAction(null) {
-        data object Settings : Navigation(SettingsOptionScreens.SETTINGS)
+    sealed class Navigation(
+        val destination: SettingsOptionScreens,
+        val isSelected: (SettingsOptionScreens?) -> Boolean,
+    ) : MyAccountSettingAction(null) {
+        data object Settings : Navigation(SettingsOptionScreens.SETTINGS, { it is SettingsOptionScreens })
 
         companion object {
             val entries = arrayOf(Settings)

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/MyAccountScreenWrapper.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/settings/MyAccountScreenWrapper.kt
@@ -185,7 +185,7 @@ private fun ListPane(
                 }
             }
         },
-        getSelectedSetting = { MyAccountSettingAction.Navigation.entries.firstOrNull { it.destination == navigator.currentDestination?.contentKey } },
+        getSelectedSetting = { MyAccountSettingAction.Navigation.entries.firstOrNull { it.isSelected(navigator.currentDestination?.contentKey) } },
     )
 }
 


### PR DESCRIPTION
The tablet selection did not recognize nested navigations as being part of the "Settings" item