### PR TITLE
fix: Avoid reprocessing API v2 deeplink multiple times

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/TransferDetailsViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/TransferDetailsViewModel.kt
@@ -120,12 +120,19 @@ class TransferDetailsViewModel @Inject constructor(
                     isApiV2Deeplink == true -> transferManager.getTransferByLinkId(transferUuid)
                     else -> transferManager.getTransferFlow(transferUuid).first()
                 }
-                if (transfer == null && isApiV2Deeplink != null) {
-                    val transferId = handleTransferDeeplink(transferUuid, _deeplinkPassword, isApiV2Deeplink)
-                    _transferSourceFlow.emit(TransferSource.Local(transferId))
-                } else {
-                    _transferSourceFlow.emit(TransferSource.Local(transferUuid))
-                    transferManager.fetchTransfer(transferUuid)
+
+                when {
+                    transfer == null && isApiV2Deeplink != null -> {
+                        val transferId = handleTransferDeeplink(transferUuid, _deeplinkPassword, isApiV2Deeplink)
+                        _transferSourceFlow.emit(TransferSource.Local(transferId))
+                    }
+                    transfer != null -> {
+                        _transferSourceFlow.emit(TransferSource.Local(transfer.uuid))
+                        transferManager.fetchTransfer(transfer.uuid)
+                    }
+                    else -> {
+                        error("No transfer found for uuid=$transferUuid outside of deeplink context.")
+                    }
                 }
             }.cancellable().onFailure { exception ->
                 when (exception) {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/TransferDetailsViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transferdetails/TransferDetailsViewModel.kt
@@ -116,7 +116,10 @@ class TransferDetailsViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching {
                 _isWrongDeeplinkPassword.emit(false)
-                val transfer = transferManager.getTransferFlow(transferUuid).first()
+                val transfer = when {
+                    isApiV2Deeplink == true -> transferManager.getTransferByLinkId(transferUuid)
+                    else -> transferManager.getTransferFlow(transferUuid).first()
+                }
                 if (transfer == null && isApiV2Deeplink != null) {
                     val transferId = handleTransferDeeplink(transferUuid, _deeplinkPassword, isApiV2Deeplink)
                     _transferSourceFlow.emit(TransferSource.Local(transferId))

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transfers/TransfersScreenWrapper.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transfers/TransfersScreenWrapper.kt
@@ -119,7 +119,7 @@ private fun ThreePaneScaffoldNavigator<DestinationContent>.HandleDeepLink(
         val context = LocalContext.current
         val windowAdaptiveInfo = LocalWindowAdaptiveInfo.current
         LaunchedEffect(Unit) {
-            navigateToDetails(context, windowAdaptiveInfo, direction, transferUuid)
+            navigateToDetails(context, windowAdaptiveInfo, direction, transferUuid, isDeeplinkNavigation = true)
         }
     }
 }
@@ -164,13 +164,15 @@ private suspend fun ThreePaneScaffoldNavigator<DestinationContent>.navigateToDet
     windowAdaptiveInfo: WindowAdaptiveInfo,
     direction: TransferDirection,
     transferUuid: String,
+    isDeeplinkNavigation: Boolean = false,
 ) {
     val matomoScreen = when (direction) {
         TransferDirection.SENT -> MatomoScreen.SentTransferDetails
         TransferDirection.RECEIVED -> MatomoScreen.ReceivedTransferDetails
     }
     MatomoSwissTransfer.trackScreen(matomoScreen)
-    selectItem(context, windowAdaptiveInfo, DestinationContent.RootLevel(direction, transferUuid))
+    val item = DestinationContent.RootLevel(direction, transferUuid, isDeeplinkNavigation)
+    selectItem(context, windowAdaptiveInfo, item)
 }
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
@@ -210,7 +212,7 @@ private fun DetailPane(
             TransferDetailsScreen(
                 transferUuid = destinationContent.transferUuid,
                 direction = destinationContent.direction,
-                isApiV2Deeplink = isApiV2Deeplink,
+                isApiV2Deeplink = isApiV2Deeplink.takeIf { destinationContent.isDeeplinkNavigation },
                 navigateBack = navigateBack,
                 navigateToFolder = { selectedFolderUuid ->
                     scope.launch {
@@ -300,6 +302,7 @@ private sealed interface DestinationContent : Parcelable {
     data class RootLevel(
         override val direction: TransferDirection,
         override val transferUuid: String,
+        val isDeeplinkNavigation: Boolean,
     ) : DestinationContent
 
     @Parcelize

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ coreSplashscreen = "1.2.0"
 desugarJDK = "2.1.5"
 qrose = "1.0.1"
 room = "2.8.4"
-swisstransfer = "7.1.1"
+swisstransfer = "8.0.0"
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }


### PR DESCRIPTION
**Description**
Currently, when you have an APIv2 deep link with a folder, as long as you navigate within the folder and return to the root transfer, you can duplicate the data because, as long as the intent is active and you return to the root of a transfer, the transfer is re-added to the database each time you return.

**Fix**
Handle API v2 deeplink flow correctly to prevent duplicate processing
while the intent is still active.