### PR TITLE
fix: Resolve correct transfer direction for API v2 deeplink

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/MainActivity.kt
@@ -45,6 +45,7 @@ import com.infomaniak.core.inappupdate.updatemanagers.InAppUpdateManager
 import com.infomaniak.multiplatform_swisstransfer.common.models.TransferDirection
 import com.infomaniak.multiplatform_swisstransfer.data.DeepLinkType
 import com.infomaniak.multiplatform_swisstransfer.managers.TransferManager
+import com.infomaniak.multiplatform_swisstransfer.network.utils.ApiUrlMatcher
 import com.infomaniak.swisstransfer.R
 import com.infomaniak.swisstransfer.ui.components.ButtonType
 import com.infomaniak.swisstransfer.ui.components.LargeButton
@@ -103,8 +104,10 @@ class MainActivity : ComponentActivity(), AppReviewManageable, AppUpdateManageab
                     intent.setData(null)
                 }
                 is DeepLinkType.OpenTransfer -> {
-                    deeplinkTransferDirection = deeplinkViewModel.getDeeplinkTransferDirection(deepLinkTypeFromURL.uuid)
-                        ?: TransferDirection.RECEIVED
+                    deeplinkTransferDirection = deeplinkViewModel.getDeeplinkTransferDirection(
+                        transferUuid = deepLinkTypeFromURL.uuid,
+                        isApiV2 = ApiUrlMatcher.isV2Url(deeplinkUrl),
+                    ) ?: TransferDirection.RECEIVED
                     if (deeplinkTransferDirection == TransferDirection.SENT) {
                         // Modify the intent to avoid conflict between the `Sent` and `Received` deeplinks
                         intent.setData((deeplinkUrl + SENT_DEEPLINK_SUFFIX).toUri())

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/MainActivity.kt
@@ -105,7 +105,7 @@ class MainActivity : ComponentActivity(), AppReviewManageable, AppUpdateManageab
                 }
                 is DeepLinkType.OpenTransfer -> {
                     deeplinkTransferDirection = deeplinkViewModel.getDeeplinkTransferDirection(
-                        transferUuid = deepLinkTypeFromURL.uuid,
+                        transferIdOrLinkId = deepLinkTypeFromURL.uuid,
                         isApiV2 = ApiUrlMatcher.isV2Url(deeplinkUrl),
                     ) ?: TransferDirection.RECEIVED
                     if (deeplinkTransferDirection == TransferDirection.SENT) {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/DeeplinkViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/DeeplinkViewModel.kt
@@ -36,8 +36,11 @@ class DeeplinkViewModel @Inject constructor(
         if (!isDeeplinkConsumed.value) savedStateHandle[IS_DEEPLINK_CONSUMED_KEY] = true
     }
 
-    suspend fun getDeeplinkTransferDirection(transferUuid: String): TransferDirection? {
-        return transferManager.getTransferByUUID(transferUuid)?.direction
+    suspend fun getDeeplinkTransferDirection(transferUuid: String, isApiV2: Boolean): TransferDirection? {
+        return when {
+            isApiV2 -> transferManager.getTransferByLinkId(transferUuid)?.direction
+            else -> transferManager.getTransferByUUID(transferUuid)?.direction
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/DeeplinkViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/DeeplinkViewModel.kt
@@ -36,10 +36,10 @@ class DeeplinkViewModel @Inject constructor(
         if (!isDeeplinkConsumed.value) savedStateHandle[IS_DEEPLINK_CONSUMED_KEY] = true
     }
 
-    suspend fun getDeeplinkTransferDirection(transferUuid: String, isApiV2: Boolean): TransferDirection? {
+    suspend fun getDeeplinkTransferDirection(transferIdOrLinkId: String, isApiV2: Boolean): TransferDirection? {
         return when {
-            isApiV2 -> transferManager.getTransferByLinkId(transferUuid)?.direction
-            else -> transferManager.getTransferByUUID(transferUuid)?.direction
+            isApiV2 -> transferManager.getTransferByLinkId(transferIdOrLinkId)?.direction
+            else -> transferManager.getTransferByUUID(transferIdOrLinkId)?.direction
         }
     }
 


### PR DESCRIPTION
Determine transfer direction using linkId for API v2 deeplinks instead of UUID, ensuring correct navigation to Sent or Received views.

Depends on #631 