### PR TITLE
fix: Change accessibility description from chevron icon to card item

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransferItem.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransferItem.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
@@ -87,8 +88,8 @@ fun TransferItem(
 
     Card(
         modifier = Modifier.semantics{
-            contentDescription = cardContentDescription
             role = Role.Button
+            onClick(cardContentDescription, null)
         },
         onClick = onClick,
         colors = CardDefaults.cardColors(containerColor = SwissTransferTheme.materialColors.surfaceContainerHighest),

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransferItem.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/components/transfer/TransferItem.kt
@@ -40,6 +40,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.infomaniak.core.ui.compose.margin.Margin
@@ -78,7 +83,13 @@ fun TransferItem(
         null
     }
 
+    val cardContentDescription = stringResource(R.string.contentDescriptionViewTransferDetails)
+
     Card(
+        modifier = Modifier.semantics{
+            contentDescription = cardContentDescription
+            role = Role.Button
+        },
         onClick = onClick,
         colors = CardDefaults.cardColors(containerColor = SwissTransferTheme.materialColors.surfaceContainerHighest),
         shape = shape,
@@ -121,7 +132,7 @@ fun TransferItem(
             Spacer(Modifier.width(Margin.Medium))
             Icon(
                 imageVector = AppIcons.ChevronRightThick,
-                contentDescription = stringResource(R.string.contentDescriptionViewTransferDetails),
+                contentDescription = null,
                 modifier = Modifier.size(Dimens.SmallIconSize),
                 tint = SwissTransferTheme.colors.iconColor,
             )


### PR DESCRIPTION
Update the semantics modifier on the card item to sets the accessibility action label instead of a content description the chevron icon. Set the role to Button to properly indicate that the entire card is clickable.