### PR TITLE
fix: Display create first transfer logic

### DIFF
--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/received/ReceivedScreen.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/received/ReceivedScreen.kt
@@ -59,7 +59,7 @@ fun ReceivedScreen(
 ) {
 
     val uiState by transfersViewModel.receivedTransfersUiState.collectAsStateWithLifecycle()
-    val sentTransfersAreEmpty by transfersViewModel.sentTransfersAreEmpty.collectAsStateWithLifecycle()
+    val hasNoTransfers by transfersViewModel.allTransfersAreEmpty.collectAsStateWithLifecycle()
 
     hasTransfer((uiState as? TransferUiState.Success)?.data?.isNotEmpty() == true)
 
@@ -67,7 +67,7 @@ fun ReceivedScreen(
 
     ReceivedScreen(
         uiState = { uiState },
-        isFirstTransfer = { sentTransfersAreEmpty },
+        isFirstTransfer = { hasNoTransfers },
         navigateToDetails = navigateToDetails,
         getSelectedTransferUuid = getSelectedTransferUuid,
         onDeleteTransfer = { transferUuid ->

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transfers/TransfersViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transfers/TransfersViewModel.kt
@@ -17,8 +17,6 @@
  */
 package com.infomaniak.swisstransfer.ui.screen.main.transfers
 
-import androidx.compose.runtime.mutableStateMapOf
-import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.infomaniak.core.common.cancellable
@@ -32,6 +30,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -54,11 +53,16 @@ class TransfersViewModel @Inject constructor(
         .map { TransferUiState.Success(it.groupBySection()) }
         .stateIn(viewModelScope, SharingStarted.Lazily, initialValue = TransferUiState.Loading)
 
-    val sentTransfersAreEmpty: StateFlow<Boolean> = transferManager.getTransfersCount(TransferDirection.SENT)
-        .map { it == 0L }
-        .stateIn(viewModelScope, SharingStarted.Lazily, initialValue = false)
-
-    val selectedTransferUuids: SnapshotStateMap<String, Boolean> = mutableStateMapOf()
+    val allTransfersAreEmpty: StateFlow<Boolean> = combine(
+        transferManager.getTransfersCount(TransferDirection.RECEIVED),
+        transferManager.getTransfersCount(TransferDirection.SENT),
+    ) { receivedCount, sentCount ->
+        receivedCount + sentCount == 0L
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Lazily,
+        initialValue = false,
+    )
 
     fun fetchPendingTransfers() {
         viewModelScope.launch(ioDispatcher) {

--- a/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transfers/TransfersViewModel.kt
+++ b/app/src/main/java/com/infomaniak/swisstransfer/ui/screen/main/transfers/TransfersViewModel.kt
@@ -57,12 +57,8 @@ class TransfersViewModel @Inject constructor(
         transferManager.getTransfersCount(TransferDirection.RECEIVED),
         transferManager.getTransfersCount(TransferDirection.SENT),
     ) { receivedCount, sentCount ->
-        receivedCount + sentCount == 0L
-    }.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.Lazily,
-        initialValue = false,
-    )
+        receivedCount == 0L && sentCount == 0L
+    }.stateIn(scope = viewModelScope, started = SharingStarted.Lazily, initialValue = false)
 
     fun fetchPendingTransfers() {
         viewModelScope.launch(ioDispatcher) {


### PR DESCRIPTION
The 'Make your first transfer!' text was displayed even if you had received transfers previously. Consequently, if you had too many transfer items, the text overlapped with them. 

FYI: iOS don't display the text if you received transfers.
 
<img width="269" height="112" alt="image" src="https://github.com/user-attachments/assets/ef57b5f4-54c2-421f-a933-04c4255528ce" />
