### PR TITLE
chore: Add .github/copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,45 @@
+# Copilot Coding Agent Onboarding — android-SwissTransfer
+
+> **Read `AGENTS.md` first** for architecture and conventions. This file covers build, CI, and validation.
+
+## Overview
+SwissTransfer for Android — secure file transfer up to 50 GB. Pure Kotlin + Jetpack Compose, Hilt DI, KMP business/networking logic via the `multiplatform-SwissTransfer` library. Two flavors: `prod` and `preprod`.
+
+## One-Time Environment Setup
+```bash
+git submodule update --init --recursive   # Core submodule — required for Gradle settings plugin
+cp env.example.properties env.properties
+echo "sentryAuthToken=DummyToken" > env.properties   # required even for debug builds
+```
+Missing `env.properties` → Gradle config phase fails.
+
+## Build & Test (CI: `.github/workflows/android.yml`)
+```bash
+./gradlew clean
+./gradlew assembleDebug          # or assembleProdDebug / assemblePreprodDebug
+./gradlew lint
+./gradlew testProdDebugUnitTest --stacktrace
+```
+CI runs all four steps in order on every non-draft PR.
+
+## Project Layout
+```
+app/
+├── src/
+│   ├── main/java/com/infomaniak/swisstransfer/
+│   │   ├── di/            # Hilt modules
+│   │   ├── ui/            # Compose screens (upload, download, settings, transfers list)
+│   │   └── workers/       # WorkManager (upload chunking)
+│   ├── prod/              # Prod-flavor sources (API endpoints, app ID)
+│   └── preprod/           # Preprod-flavor overrides
+Core/                       # Git submodule — Infomaniak Core
+gradle/libs.versions.toml
+settings.gradle.kts         # includes Core/build-logic
+```
+
+## Key Rules
+- All networking/business logic lives in `multiplatform-SwissTransfer` (KMP) — Android layer is UI + DI only.
+- `prod` is the default/release flavor; `preprod` points to staging servers.
+- No Firebase or Google services — app is distributed on both Google Play and F-Droid.
+- All user-visible strings in `res/values/strings.xml`.
+- When adding/removing a runtime dependency, update `LICENSES.md` at the repo root.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,7 +16,7 @@ Missing `env.properties` → Gradle config phase fails.
 ## Build & Test (CI: `.github/workflows/android.yml`)
 ```bash
 ./gradlew clean
-./gradlew assembleDebug          # or assembleProdDebug / assemblePreprodDebug
+./gradlew assembleDebug
 ./gradlew lint
 ./gradlew testProdDebugUnitTest --stacktrace
 ```
@@ -28,18 +28,18 @@ app/
 ├── src/
 │   ├── main/java/com/infomaniak/swisstransfer/
 │   │   ├── di/            # Hilt modules
-│   │   ├── ui/            # Compose screens (upload, download, settings, transfers list)
+│   │   ├── ui/            # Compose screens
 │   │   └── workers/       # WorkManager (upload chunking)
-│   ├── prod/              # Prod-flavor sources (API endpoints, app ID)
+│   ├── prod/              # Prod-flavor sources
 │   └── preprod/           # Preprod-flavor overrides
 Core/                       # Git submodule — Infomaniak Core
 gradle/libs.versions.toml
-settings.gradle.kts         # includes Core/build-logic
 ```
 
-## Key Rules
-- All networking/business logic lives in `multiplatform-SwissTransfer` (KMP) — Android layer is UI + DI only.
-- `prod` is the default/release flavor; `preprod` points to staging servers.
-- No Firebase or Google services — app is distributed on both Google Play and F-Droid.
-- All user-visible strings in `res/values/strings.xml`.
+## PR Review Instructions
+
+- Ensure strings are localized via `strings.xml` resources.
+- Ensure UI is written in Jetpack Compose using Material3 components — this is a pure Compose app, do not introduce XML layouts.
+- All networking and business logic lives in the `multiplatform-SwissTransfer` KMP library — the Android layer is UI + DI only. Avoid duplicating logic in the Android layer.
+- `prod` is the default/release flavor; `preprod` points to staging servers — ensure flavor-specific code stays in the correct source sets.
 - When adding/removing a runtime dependency, update `LICENSES.md` at the repo root.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,10 +8,9 @@ SwissTransfer for Android — secure file transfer up to 50 GB. Pure Kotlin + Je
 ## One-Time Environment Setup
 ```bash
 git submodule update --init --recursive   # Core submodule — required for Gradle settings plugin
-cp env.example.properties env.properties
-echo "sentryAuthToken=DummyToken" > env.properties   # required even for debug builds
+echo "sentryAuthToken=DummyToken" > env.properties   # only required for release builds; debug builds work without it
 ```
-Missing `env.properties` → Gradle config phase fails.
+Missing `Core/` submodule → Gradle config phase fails. Missing `env.properties` only blocks *release* tasks (requires `sentryAuthToken`); debug builds work without it.
 
 ## Build & Test (CI: `.github/workflows/android.yml`)
 ```bash
@@ -29,7 +28,7 @@ app/
 │   ├── main/java/com/infomaniak/swisstransfer/
 │   │   ├── di/            # Hilt modules
 │   │   ├── ui/            # Compose screens
-│   │   └── workers/       # WorkManager (upload chunking)
+│   │   └── workers/       # Upload chunk sizing / background helpers
 │   ├── prod/              # Prod-flavor sources
 │   └── preprod/           # Preprod-flavor overrides
 Core/                       # Git submodule — Infomaniak Core
@@ -40,6 +39,6 @@ gradle/libs.versions.toml
 
 - Ensure strings are localized via `strings.xml` resources.
 - Ensure UI is written in Jetpack Compose using Material3 components — this is a pure Compose app, do not introduce XML layouts.
-- All networking and business logic lives in the `multiplatform-SwissTransfer` KMP library — the Android layer is UI + DI only. Avoid duplicating logic in the Android layer.
+- All networking and business logic lives in the `multiplatform-SwissTransfer` KMP library — keep the Android layer focused on UI, DI, and platform integration (services/workers) without duplicating business rules.
 - `prod` is the default/release flavor; `preprod` points to staging servers — ensure flavor-specific code stays in the correct source sets.
 - When adding/removing a runtime dependency, update `LICENSES.md` at the repo root.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ SwissTransfer for Android — secure file transfer up to 50 GB. Pure Kotlin + Je
 ## One-Time Environment Setup
 ```bash
 git submodule update --init --recursive   # Core submodule — required for Gradle settings plugin
-echo "sentryAuthToken=DummyToken" > env.properties   # only required for release builds; debug builds work without it
+cp env.example.properties env.properties  # only required for release builds; debug builds work without it
 ```
 Missing `Core/` submodule → Gradle config phase fails. Missing `env.properties` only blocks *release* tasks (requires `sentryAuthToken`); debug builds work without it.
 


### PR DESCRIPTION
## Summary
Adds `.github/copilot-instructions.md` to onboard the Copilot cloud agent to this repository.

The file covers:
- What the repository does (purpose, language, architecture)
- One-time environment setup (submodules, env files)
- Build, test, and lint commands that match CI exactly
- Project layout (key paths and modules)
- Rules to prevent common CI failures

## Related
Part of a batch PR across all Infomaniak Android repos to improve Copilot agent quality.
